### PR TITLE
Patch NetHttpResponse to detect abrupt termination

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/http/javanet/NetHttpResponse.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/javanet/NetHttpResponse.java
@@ -16,6 +16,7 @@ package com.google.api.client.http.javanet;
 
 import com.google.api.client.http.LowLevelHttpResponse;
 
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
@@ -70,14 +71,27 @@ final class NetHttpResponse extends LowLevelHttpResponse {
    * with version 1.17 it returns {@link HttpURLConnection#getInputStream} when it doesn't throw
    * {@link IOException}, otherwise it returns {@link HttpURLConnection#getErrorStream}
    * </p>
+   *
+   * <p>
+   * Upgrade warning: in versions prior to 1.20 {@link #getContent()} returned
+   * {@link HttpURLConnection#getInputStream()} or {@link HttpURLConnection#getErrorStream()}, both
+   * of which silently returned -1 for read() calls when the connection got closed in the middle
+   * of receiving a response. This is highly likely a bug from JDK's {@link HttpURLConnection}.
+   * Since version 1.20, the bytes read off the wire will be checked and an {@link IOException} will
+   * be thrown if the response is not fully delivered when the connection is closed by server for
+   * whatever reason, e.g., server restarts. Note though that this is a best-effort check: when the
+   * response is chunk encoded, we have to rely on the underlying HTTP library to behave correctly.
+   * </p>
    */
   @Override
   public InputStream getContent() throws IOException {
+    InputStream in = null;
     try {
-      return connection.getInputStream();
+      in = connection.getInputStream();
     } catch (IOException ioe) {
-      return connection.getErrorStream();
+      in = connection.getErrorStream();
     }
+    return in == null ? null : new SizeValidatingInputStream(in);
   }
 
   @Override
@@ -130,5 +144,64 @@ final class NetHttpResponse extends LowLevelHttpResponse {
   @Override
   public void disconnect() {
     connection.disconnect();
+  }
+
+  /**
+   * A wrapper arround the base {@link InputStream} that validates EOF returned by the read calls.
+   *
+   * @since 1.20
+   */
+  private final class SizeValidatingInputStream extends FilterInputStream {
+
+    private long bytesRead = 0;
+
+    public SizeValidatingInputStream(InputStream in) {
+      super(in);
+    }
+
+    /**
+     * java.io.InputStream#read(byte[], int, int) swallows IOException thrown from read() so we have
+     * to override it.
+     * @see "http://grepcode.com/file/repository.grepcode.com/java/root/jdk/openjdk/8-b132/java/io/InputStream.java#185"
+     */
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+      int n = in.read(b, off, len);
+      if (n == -1) {
+        throwIfFalseEOF();
+      } else {
+        bytesRead += n;
+      }
+      return n;
+    }
+
+    @Override
+    public int read() throws IOException {
+      int n = in.read();
+      if (n == -1) {
+        throwIfFalseEOF();
+      } else {
+        bytesRead++;
+      }
+      return n;
+    }
+
+    // Throws an IOException if gets an EOF in the middle of a response.
+    private void throwIfFalseEOF() throws IOException {
+      long contentLength = getContentLength();
+      if (contentLength == -1) {
+        // If a Content-Length header is missing, there's nothing we can do.
+        return;
+      }
+      // According to RFC2616, message-body is prohibited in responses to certain requests, e.g.,
+      // HEAD. Nevertheless an entity-header (possibly with non-zero Content-Length) may be present.
+      // Thus we exclude the case where bytesRead == 0.
+      //
+      // See http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.4 for details.
+      if (bytesRead != 0 && bytesRead < contentLength) {
+        throw new IOException("Connection closed prematurely: bytesRead = " + bytesRead
+            + ", Content-Length = " + contentLength);
+      }
+    }
   }
 }

--- a/google-http-client/src/main/java/com/google/api/client/testing/http/javanet/MockHttpURLConnection.java
+++ b/google-http-client/src/main/java/com/google/api/client/testing/http/javanet/MockHttpURLConnection.java
@@ -17,7 +17,6 @@ package com.google.api.client.testing.http.javanet;
 import com.google.api.client.util.Beta;
 import com.google.api.client.util.Preconditions;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -25,6 +24,10 @@ import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.UnknownServiceException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  * {@link Beta} <br/>
@@ -52,20 +55,28 @@ public class MockHttpURLConnection extends HttpURLConnection {
   /**
    * The input byte array which represents the content when the status code is less then
    * {@code 400}.
+   *
+   * @deprecated As of 1.20. Use {@link #setInputStream(InputStream)} instead.
    */
+  @Deprecated
   public static final byte[] INPUT_BUF = new byte[1];
 
   /**
    * The error byte array which represents the content when the status code is greater or equal to
    * {@code 400}.
+   *
+   * @deprecated As of 1.20. Use {@link #setErrorStream(InputStream)} instead.
    */
+  @Deprecated
   public static final byte[] ERROR_BUF = new byte[5];
 
   /** The input stream. */
-  private InputStream inputStream = new ByteArrayInputStream(INPUT_BUF);
+  private InputStream inputStream = null;
 
   /** The error stream. */
-  private InputStream errorStream = new ByteArrayInputStream(ERROR_BUF);
+  private InputStream errorStream = null;
+
+  private Map<String, List<String>> headers = new LinkedHashMap<String, List<String>>();
 
   /**
    * @param u the URL or {@code null} for none
@@ -130,6 +141,54 @@ public class MockHttpURLConnection extends HttpURLConnection {
     return this;
   }
 
+  /**
+   * Sets a custom response header.
+   *
+   * @since 1.20
+   */
+  public MockHttpURLConnection addHeader(String name, String value) {
+    Preconditions.checkNotNull(name);
+    Preconditions.checkNotNull(value);
+    if (headers.containsKey(name)) {
+      headers.get(name).add(value);
+    } else {
+      List<String> values = new ArrayList<String>();
+      values.add(value);
+      headers.put(name, values);
+    }
+    return this;
+  }
+
+  /**
+   * Sets the input stream.
+   *
+   * <p>To prevent incidental overwrite, only the first non-null assignment is honored.
+   *
+   * @since 1.20
+   */
+  public MockHttpURLConnection setInputStream(InputStream is) {
+    Preconditions.checkNotNull(is);
+    if (inputStream == null) {
+      inputStream = is;
+    }
+    return this;
+  }
+
+  /**
+   * Sets the error stream.
+   *
+   * <p>To prevent incidental overwrite, only the first non-null assignment is honored.
+   *
+   * @since 1.20
+   */
+  public MockHttpURLConnection setErrorStream(InputStream is) {
+    Preconditions.checkNotNull(is);
+    if (errorStream == null) {
+      errorStream = is;
+    }
+    return this;
+  }
+
   @Override
   public InputStream getInputStream() throws IOException {
     if (responseCode < 400) {
@@ -141,5 +200,16 @@ public class MockHttpURLConnection extends HttpURLConnection {
   @Override
   public InputStream getErrorStream() {
     return errorStream;
+  }
+
+  @Override
+  public Map<String, List<String>> getHeaderFields() {
+    return headers;
+  }
+
+  @Override
+  public String getHeaderField(String name) {
+    List<String> values = headers.get(name);
+    return values == null ? null : values.get(0);
   }
 }

--- a/google-http-client/src/test/java/com/google/api/client/testing/http/javanet/MockHttpUrlConnectionTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/testing/http/javanet/MockHttpUrlConnectionTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.api.client.testing.http.javanet;
+
+import com.google.api.client.testing.http.HttpTesting;
+import com.google.api.client.util.StringUtils;
+
+import junit.framework.TestCase;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Tests {@link MockHttpURLConnection}.
+ */
+public class MockHttpUrlConnectionTest extends TestCase {
+
+  private static final String RESPONSE_BODY = "body";
+  private static final String HEADER_NAME = "Custom-Header";
+
+  public void testSetGetHeaders() throws IOException {
+      MockHttpURLConnection connection = new MockHttpURLConnection(new URL(HttpTesting.SIMPLE_URL));
+      connection.addHeader(HEADER_NAME, "100");
+      assertEquals("100", connection.getHeaderField(HEADER_NAME));
+  }
+
+  public void testSetGetMultipleHeaders() throws IOException {
+      MockHttpURLConnection connection = new MockHttpURLConnection(new URL(HttpTesting.SIMPLE_URL));
+      List<String> values = Arrays.asList("value1", "value2", "value3");
+      for (String value : values) {
+        connection.addHeader(HEADER_NAME, value);
+      }
+      Map<String, List<String>> headers = connection.getHeaderFields();
+      assertEquals(3, headers.get(HEADER_NAME).size());
+      for (int i = 0; i < 3; i++) {
+        assertEquals(values.get(i), headers.get(HEADER_NAME).get(i));
+      }
+  }
+
+  public void testGetNonExistingHeader() throws IOException {
+      MockHttpURLConnection connection = new MockHttpURLConnection(new URL(HttpTesting.SIMPLE_URL));
+      assertNull(connection.getHeaderField(HEADER_NAME));
+  }
+
+  public void testSetInputStreamAndInputStreamImmutable() throws IOException {
+      MockHttpURLConnection connection = new MockHttpURLConnection(new URL(HttpTesting.SIMPLE_URL));
+      connection.setInputStream(new ByteArrayInputStream(StringUtils.getBytesUtf8(RESPONSE_BODY)));
+      connection.setInputStream(new ByteArrayInputStream(StringUtils.getBytesUtf8("override")));
+      byte[] buf = new byte[10];
+      InputStream in = connection.getInputStream();
+      int n = 0, bytes = 0;
+      while ((n = in.read(buf)) != -1) {
+        bytes += n;
+      }
+      assertEquals(RESPONSE_BODY, new String(buf, 0, bytes));
+  }
+}


### PR DESCRIPTION
  JDK's HttpUrlConnection implementation fails to notify clients when the
  connection is lost when reading a response, e.g., the server gets restarted.
  This changelist patches the NetHttpResponse to detect abrupt connection
  termination when a fixed content length is available. In the case where
  responses are chunk encoded, connection lost is well handled by JDK.

  Also extend MockHttpUrlConnection for more testing functionalities.