### PR TITLE
Trim spaces before and after header values

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/util/Data.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/Data.java
@@ -398,6 +398,8 @@ public class Data {
           || primitiveClass.isAssignableFrom(String.class)) {
         return stringValue;
       }
+      // The following primite types doesn't allow spaces
+      stringValue = stringValue.trim();
       if (primitiveClass == Character.class || primitiveClass == char.class) {
         if (stringValue.length() != 1) {
           throw new IllegalArgumentException(

--- a/google-http-client/src/main/java/com/google/api/client/util/Data.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/Data.java
@@ -398,7 +398,7 @@ public class Data {
           || primitiveClass.isAssignableFrom(String.class)) {
         return stringValue;
       }
-      // The following primite types doesn't allow spaces
+      // The following primitive types doesn't allow spaces
       stringValue = stringValue.trim();
       if (primitiveClass == Character.class || primitiveClass == char.class) {
         if (stringValue.length() != 1) {


### PR DESCRIPTION
Need to trim spaces on header values when their types maps to primitives.
e.g. when we try to parse "23      " to long we have a NumberFormatException if the spaces are not trimmed.

example of exception:

```
java.lang.NumberFormatException: For input string: "23        "
    at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
    at java.lang.Long.parseLong(Long.java:441)
    at java.lang.Long.valueOf(Long.java:540)
    at com.google.api.client.util.Data.parsePrimitiveValue(Data.java:421)
    at com.google.api.client.http.HttpHeaders.parseValue(HttpHeaders.java:1178)
    at com.google.api.client.http.HttpHeaders.parseHeader(HttpHeaders.java:1159)
    at com.google.api.client.http.HttpHeaders.fromHttpResponse(HttpHeaders.java:989)
    at com.google.api.client.http.HttpResponse.<init>(HttpResponse.java:148)
    at com.google.api.client.http.HttpRequest.execute(HttpRequest.java:976)
```
