### PR TITLE
Async request

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/http/HttpResponseCallback.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpResponseCallback.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.api.client.http;
+
+import java.io.IOException;
+
+/**
+ *
+ * HTTP response callback for asynchronous computation.
+ *
+ * <p>
+ * This callback is used with either {@link HttpRequest#executeAsync(java.util.concurrent.Executor, HttpResponseCallback)}
+ * or {@link HttpRequest#executeAsync(HttpResponseCallback)}
+ * to execute the HTTP request in a asynchronous non-blocking fashion.
+ * </p>
+ *
+ * @author hussachai@gmail.com (Hussachai Puripunpinyo)
+ *
+ * @since 1.21
+ */
+public interface HttpResponseCallback {
+
+  /**
+   * This method will be called when a Future is completed with either
+   * failure or success.
+   * @since 1.21
+   */
+  public void onComplete();
+
+  /**
+   * This method will be called when a Future is completed with no error.
+   * @param response
+   * @since 1.21
+   */
+  public void onSuccess(HttpResponse response) throws IOException;
+
+  /**
+   * This method will be called when a Future is completed with an error.
+   * @param throwable
+   * @since 1.21
+   */
+  public void onFailure(Throwable throwable);
+
+  /**
+   * This method will be called when a Future is cancelled.
+   * There is no guarantee that the HTTP request is executed.
+   * @since 1.21
+   */
+  public void onInterrupted();
+
+}

--- a/google-http-client/src/main/java/com/google/api/client/http/HttpResponseCallbackAdapter.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpResponseCallbackAdapter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2015 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.api.client.http;
+
+/**
+ *
+ * Generic HTTP response callback for asynchronous computation.
+ *
+ * <p>
+ * An implementation of {@link HttpResponseCallback} with empty methods
+ * allowing sub-classes to override only methods that they're interested in.
+ *
+ * This class implements all interfaces defined in {@link HttpResponseCallback}
+ * excepts {@link #onSuccess(HttpResponse)}
+ * </p>
+ *
+ * @author hussachai@gmail.com (Hussachai Puripunpinyo)
+ *
+ * @since 1.21
+ *
+ */
+public abstract class HttpResponseCallbackAdapter implements HttpResponseCallback {
+
+  /**
+   * {@inheritDoc}
+   * <p>This implementation is empty. </p>
+   */
+  public void onComplete() {
+  }
+
+  /**
+   * {@inheritDoc}
+   * <p>This implementation is empty. </p>
+   */
+  public void onFailure(Throwable throwable) {
+  }
+
+  /**
+   * {@inheritDoc}
+   * <p>This implementation is empty. </p>
+   */
+  public void onInterrupted() {
+  }
+
+
+}

--- a/google-http-client/src/main/java/com/google/api/client/http/javanet/DefaultConnectionFactory.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/javanet/DefaultConnectionFactory.java
@@ -26,7 +26,7 @@ public class DefaultConnectionFactory implements ConnectionFactory {
     this.proxy = proxy;
   }
 
-  @Override
+
   public HttpURLConnection openConnection(URL url) throws IOException {
     return (HttpURLConnection) (proxy == null ? url.openConnection() : url.openConnection(proxy));
   }

--- a/pom.xml
+++ b/pom.xml
@@ -584,6 +584,8 @@
     </plugins>
   </build>
   <properties>
+	<maven.compiler.source>1.5</maven.compiler.source>
+    <maven.compiler.target>1.5</maven.compiler.target>
     <project.appengine.version>1.7.7</project.appengine.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.jsr305.version>1.3.9</project.jsr305.version>


### PR DESCRIPTION
I added new executeAsync methods to HttpRequest. The new approach is to use callback
instead of returning Future object and let users handle the result. It will be easily abused as
the get method on Future object is blocking thread. There is no point to create the new thread then block the current thread until we get the result from another thread.
The return type for executeAsync is FutureTask because it lets users cancel the submitted task.
I also added test case for those methods I created.

One more thing, the old executeAsync method that take no parameter, creates ThreadPool for every calls. That's kind of expensive call. Not sure whether it will make a memory leak or not but I'm feeling like it will. I didn't mark @depreciated on the old executeAsync and didn't fix the issue that I just mentioned. Just want to point out and let you guys decide what to do. Maybe I'm wrong.

This project is awesome because I don't like dealing with Apache HTTP Client configuration and
when I create a library relying on Apache HTTP Client. One of the user told me that Google AppEngine doesn't support it :(. Feel like google-http-java-client is a way to go.
