### PR TITLE
Add support for Jackson ObjectMapper

### DIFF
--- a/google-http-client-jackson2/pom.xml
+++ b/google-http-client-jackson2/pom.xml
@@ -76,6 +76,10 @@
       <artifactId>jackson-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava-jdk5</artifactId>
       <scope>test</scope>

--- a/google-http-client-jackson2/src/main/java/com/google/api/client/json/jackson2/JacksonMapperHttpContent.java
+++ b/google-http-client-jackson2/src/main/java/com/google/api/client/json/jackson2/JacksonMapperHttpContent.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2015 Dictanova SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.api.client.json.jackson2;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.client.http.AbstractHttpContent;
+import com.google.api.client.json.Json;
+import com.google.api.client.util.Preconditions;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * JSON deserializer implementation based on Jackson <i>databinding</i> module.
+ * <p>
+ * <p>Usage:
+ * <code><pre>{@code
+ * HttpContent content = new JacksonMapperHttpContent(new ObjectMapper(), data);
+ * HttpRequest request = requestFactory.buildPostRequest(url, content);
+ * HttpResponse response = request.execute();
+ * }
+ * </pre></code></p>
+ * <p>
+ * Implementation is not thread-safe.
+ * </p>
+ *
+ * @author Damien Raude-Morvan
+ */
+public class JacksonMapperHttpContent extends AbstractHttpContent {
+
+    /**
+     * JSON key name/value data.
+     */
+    private final Object data;
+
+    /**
+     * Jackson {@link ObjectMapper} that will perform databinding.
+     */
+    private final ObjectMapper objectMapper;
+
+    /**
+     * @param objectMapper Jackson databinder
+     * @param data         JSON key name/value data
+     */
+    public JacksonMapperHttpContent(final ObjectMapper objectMapper, final Object data) {
+        super(Json.MEDIA_TYPE);
+        this.objectMapper = Preconditions.checkNotNull(objectMapper);
+        this.data = Preconditions.checkNotNull(data);
+    }
+
+    public void writeTo(OutputStream out) throws IOException {
+        objectMapper.writeValue(out, data);
+    }
+
+}

--- a/google-http-client-jackson2/src/main/java/com/google/api/client/json/jackson2/JacksonMapperParser.java
+++ b/google-http-client-jackson2/src/main/java/com/google/api/client/json/jackson2/JacksonMapperParser.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2015 Dictanova SAS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package com.google.api.client.json.jackson2;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.client.util.ObjectParser;
+import com.google.api.client.util.Preconditions;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.lang.reflect.Type;
+import java.nio.charset.Charset;
+
+/**
+ * JSON serializer implementation based on Jackson <i>databinding</i> module.
+ * <p>
+ * <p>Usage:
+ * <code><pre>{@code
+ * HttpRequest request = requestFactory.buildGetRequest(url);
+ * request.setParser(new JacksonMapperParser(new ObjectMapper()));
+ * HttpResponse response = request.execute();
+ * MyDataType data = response.parseAs(MyDataType.class);
+ * }
+ * </pre></code></p>
+ * <p>
+ * Implementation is not thread-safe.
+ * </p>
+ *
+ * @author Damien Raude-Morvan
+ */
+public final class JacksonMapperParser implements ObjectParser {
+
+    /**
+     * Jackson {@link ObjectMapper} that will perform databinding.
+     */
+    private final ObjectMapper objectMapper;
+
+    /**
+     * @param objectMapper Jackson databinder
+     */
+    public JacksonMapperParser(final ObjectMapper objectMapper) {
+        this.objectMapper = Preconditions.checkNotNull(objectMapper);
+    }
+
+    public <T> T parseAndClose(final InputStream in, final Charset charset,
+                               final Class<T> dataClass) throws IOException {
+        return objectMapper.readValue(in, dataClass);
+    }
+
+    public Object parseAndClose(final InputStream in, final Charset charset,
+                                final Type dataType) throws IOException {
+        JavaType javaType = objectMapper.getTypeFactory().constructType(dataType);
+        return objectMapper.readValue(in, javaType);
+    }
+
+    public <T> T parseAndClose(final Reader reader, final Class<T> dataClass) throws IOException {
+        return objectMapper.readValue(reader, dataClass);
+    }
+
+    public Object parseAndClose(final Reader reader, final Type dataType) throws IOException {
+        JavaType javaType = objectMapper.getTypeFactory().constructType(dataType);
+        return objectMapper.readValue(reader, javaType);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,11 @@
         <version>${project.jackson-core2.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${project.jackson-core2.version}</version>
+      </dependency>
+      <dependency>
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>
         <version>${project.gson.version}</version>


### PR DESCRIPTION
Add support for Jackson 2.x ObjectMapper so that an HttpRequest could utilize Jackson2's data-binding functionality.

This closes google/google-http-java-client#261
