### PR TITLE
Ignore symbolic link test failure on jdk6

### DIFF
--- a/google-http-client/src/test/java/com/google/api/client/util/IOUtilsTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/util/IOUtilsTest.java
@@ -57,6 +57,9 @@ public class IOUtilsTest extends TestCase {
       // ignore because ln command may not be defined
       return;
     }
-    assertTrue(IOUtils.isSymbolicLink(file2));
+    // multiple versions of jdk6 cannot detect the symbolic link. Consider support best-effort on
+    // jdk6
+    boolean jdk6 = System.getProperty("java.version").startsWith("1.6.0_");
+    assertTrue(IOUtils.isSymbolicLink(file2) || jdk6);
   }
 }


### PR DESCRIPTION
Not much we can do; the platform simply fails to have useful behavior
for at least openjdk 6u34 and oracle jdk 6u45.

@madongfly, would you mind reviewing this (even though it is for the v1 library)?