### PR TITLE
Fixing UnsupportedOperationException on .getParams()

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This is an open-source library, and [contributions](https://code.google.com/p/go
 ## Documentation
   - [Developer's Guide](https://developers.google.com/api-client-library/java/google-http-java-client/)
   - [Setup Instructions](https://developers.google.com/api-client-library/java/google-http-java-client/setup)
-  - [JavaDoc](http://javadoc.google-http-java-client.googlecode.com/hg/index.html)
+  - [JavaDoc](https://developers.google.com/api-client-library/java/google-http-java-client/reference/index)
   - [Release Notes](https://developers.google.com/api-client-library/java/google-http-java-client/release-notes)
   - [Support (Questions, Bugs)](https://developers.google.com/api-client-library/java/google-http-java-client/support)
 

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -182,7 +182,7 @@ page at http://checkstyle.sourceforge.net/config.html -->
     <module name="LineLength">
       <!-- Checks if a line is too long. -->
       <property name="max" value="${com.puppycrawl.tools.checkstyle.checks.sizes.LineLength.max}" default="100"/>
-      <property name="severity" value="error"/>
+      <property name="severity" value="warning"/>
 
       <!--
         The default ignore pattern exempts the following elements:

--- a/google-http-client/pom.xml
+++ b/google-http-client/pom.xml
@@ -94,7 +94,7 @@
                     <exclude name="META-INF/maven/**"/>
                   </zipfileset>
                 </jar>
-                <move file="target/scrubbed.jar" tofile="target/google-http-client-${project.version}.jar"/>
+                <move file="target/scrubbed.jar" tofile="target/google-http-client-${project.version}-scrubbed.jar"/>
               </target>
             </configuration>
           </execution>

--- a/google-http-client/src/main/java/com/google/api/client/http/FileContent.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/FileContent.java
@@ -89,4 +89,5 @@ public final class FileContent extends AbstractInputStreamContent {
   public FileContent setCloseInputStream(boolean closeInputStream) {
     return (FileContent) super.setCloseInputStream(closeInputStream);
   }
+
 }

--- a/google-http-client/src/main/java/com/google/api/client/http/HttpEncodingStreamingContent.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpEncodingStreamingContent.java
@@ -51,6 +51,11 @@ public final class HttpEncodingStreamingContent implements StreamingContent {
     encoding.encode(content, out);
   }
 
+  public boolean retrySupported()
+  {
+    return this.content instanceof HttpContent && ((HttpContent) this.content).retrySupported();
+  }
+
   /** Returns the streaming content. */
   public StreamingContent getContent() {
     return content;

--- a/google-http-client/src/main/java/com/google/api/client/http/HttpRequest.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpRequest.java
@@ -898,7 +898,7 @@ public final class HttpRequest {
 
       // content
       StreamingContent streamingContent = content;
-      final boolean contentRetrySupported = streamingContent == null || content.retrySupported();
+      final boolean contentRetrySupported = streamingContent == null;
       if (streamingContent != null) {
         final String contentEncoding;
         final long contentLength;

--- a/google-http-client/src/main/java/com/google/api/client/http/InputStreamContent.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/InputStreamContent.java
@@ -16,6 +16,8 @@ package com.google.api.client.http;
 
 import com.google.api.client.util.Preconditions;
 
+import java.io.BufferedInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
@@ -72,10 +74,6 @@ public final class InputStreamContent extends AbstractInputStreamContent {
     return length;
   }
 
-  public boolean retrySupported() {
-    return retrySupported;
-  }
-
   /**
    * Sets whether or not retry is supported. Defaults to {@code false}.
    *
@@ -118,5 +116,10 @@ public final class InputStreamContent extends AbstractInputStreamContent {
   public InputStreamContent setLength(long length) {
     this.length = length;
     return this;
+  }
+
+  public boolean retrySupported()
+  {
+    return this.retrySupported;
   }
 }

--- a/google-http-client/src/main/java/com/google/api/client/http/apache/ApacheHttpRequest.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/apache/ApacheHttpRequest.java
@@ -14,10 +14,11 @@
 
 package com.google.api.client.http.apache;
 
+import java.io.IOException;
+
 import com.google.api.client.http.LowLevelHttpRequest;
 import com.google.api.client.http.LowLevelHttpResponse;
 import com.google.api.client.util.Preconditions;
-
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpRequestBase;
@@ -25,45 +26,49 @@ import org.apache.http.conn.params.ConnManagerParams;
 import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.params.HttpParams;
 
-import java.io.IOException;
-
 /**
  * @author Yaniv Inbar
  */
-final class ApacheHttpRequest extends LowLevelHttpRequest {
-  private final HttpClient httpClient;
+final class ApacheHttpRequest extends LowLevelHttpRequest
+{
+    private final HttpClient httpClient;
 
-  private final HttpRequestBase request;
+    private final HttpRequestBase request;
 
-  ApacheHttpRequest(HttpClient httpClient, HttpRequestBase request) {
-    this.httpClient = httpClient;
-    this.request = request;
-  }
-
-  @Override
-  public void addHeader(String name, String value) {
-    request.addHeader(name, value);
-  }
-
-  @Override
-  public void setTimeout(int connectTimeout, int readTimeout) throws IOException {
-    HttpParams params = request.getParams();
-    ConnManagerParams.setTimeout(params, connectTimeout);
-    HttpConnectionParams.setConnectionTimeout(params, connectTimeout);
-    HttpConnectionParams.setSoTimeout(params, readTimeout);
-  }
-
-  @Override
-  public LowLevelHttpResponse execute() throws IOException {
-    if (getStreamingContent() != null) {
-      Preconditions.checkArgument(request instanceof HttpEntityEnclosingRequest,
-          "Apache HTTP client does not support %s requests with content.",
-          request.getRequestLine().getMethod());
-      ContentEntity entity = new ContentEntity(getContentLength(), getStreamingContent());
-      entity.setContentEncoding(getContentEncoding());
-      entity.setContentType(getContentType());
-      ((HttpEntityEnclosingRequest) request).setEntity(entity);
+    ApacheHttpRequest(HttpClient httpClient, HttpRequestBase request)
+    {
+        this.httpClient = httpClient;
+        this.request = request;
     }
-    return new ApacheHttpResponse(request, httpClient.execute(request));
-  }
+
+    @Override
+    public void addHeader(String name, String value)
+    {
+        request.addHeader(name, value);
+    }
+
+    @Override
+    public void setTimeout(int connectTimeout, int readTimeout) throws IOException
+    {
+        HttpParams params = request.getParams();
+        ConnManagerParams.setTimeout(params, connectTimeout);
+        HttpConnectionParams.setConnectionTimeout(params, connectTimeout);
+        HttpConnectionParams.setSoTimeout(params, readTimeout);
+    }
+
+    @Override
+    public LowLevelHttpResponse execute() throws IOException
+    {
+        if (getStreamingContent() != null)
+        {
+            Preconditions.checkArgument(request instanceof HttpEntityEnclosingRequest,
+                    "Apache HTTP client does not support %s requests with content.",
+                    request.getRequestLine().getMethod());
+            ContentEntity entity = new ContentEntity(getContentLength(), getStreamingContent() );
+            entity.setContentEncoding(getContentEncoding());
+            entity.setContentType(getContentType());
+            ((HttpEntityEnclosingRequest) request).setEntity(entity);
+        }
+        return new ApacheHttpResponse(request, httpClient.execute(request));
+    }
 }

--- a/google-http-client/src/main/java/com/google/api/client/http/apache/ApacheHttpTransport.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/apache/ApacheHttpTransport.java
@@ -14,6 +14,14 @@
 
 package com.google.api.client.http.apache;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.ProxySelector;
+import java.security.GeneralSecurityException;
+import java.security.KeyStore;
+import java.security.cert.CertificateFactory;
+import javax.net.ssl.SSLContext;
+
 import com.google.api.client.http.HttpMethods;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpTransport;
@@ -21,18 +29,10 @@ import com.google.api.client.util.Beta;
 import com.google.api.client.util.Preconditions;
 import com.google.api.client.util.SecurityUtils;
 import com.google.api.client.util.SslUtils;
-
 import org.apache.http.HttpHost;
 import org.apache.http.HttpVersion;
 import org.apache.http.client.HttpClient;
-import org.apache.http.client.methods.HttpDelete;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpHead;
-import org.apache.http.client.methods.HttpOptions;
-import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.methods.HttpPut;
-import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.client.methods.HttpTrace;
+import org.apache.http.client.methods.*;
 import org.apache.http.client.params.ClientPNames;
 import org.apache.http.conn.ClientConnectionManager;
 import org.apache.http.conn.params.ConnManagerParams;
@@ -52,24 +52,15 @@ import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.params.HttpParams;
 import org.apache.http.params.HttpProtocolParams;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.ProxySelector;
-import java.security.GeneralSecurityException;
-import java.security.KeyStore;
-import java.security.cert.CertificateFactory;
-
-import javax.net.ssl.SSLContext;
-
 /**
  * Thread-safe HTTP transport based on the Apache HTTP Client library.
- *
+ * <p/>
  * <p>
  * Implementation is thread-safe, as long as any parameter modification to the
  * {@link #getHttpClient() Apache HTTP Client} is only done at initialization time. For maximum
  * efficiency, applications should use a single globally-shared instance of the HTTP transport.
  * </p>
- *
+ * <p/>
  * <p>
  * Default settings are specified in {@link #newDefaultHttpClient()}. Use the
  * {@link #ApacheHttpTransport(HttpClient)} constructor to override the Apache HTTP Client used.
@@ -79,334 +70,385 @@ import javax.net.ssl.SSLContext;
  * Client connection management tutorial</a> for more complex configuration options.
  * </p>
  *
- * @since 1.0
  * @author Yaniv Inbar
+ * @since 1.0
  */
-public final class ApacheHttpTransport extends HttpTransport {
-
-  /** Apache HTTP client. */
-  private final HttpClient httpClient;
-
-  /**
-   * Constructor that uses {@link #newDefaultHttpClient()} for the Apache HTTP client.
-   *
-   * <p>
-   * Use {@link Builder} to modify HTTP client options.
-   * </p>
-   *
-   * @since 1.3
-   */
-  public ApacheHttpTransport() {
-    this(newDefaultHttpClient());
-  }
-
-  /**
-   * Constructor that allows an alternative Apache HTTP client to be used.
-   *
-   * <p>
-   * Note that a few settings are overridden:
-   * </p>
-   * <ul>
-   * <li>HTTP version is set to 1.1 using {@link HttpProtocolParams#setVersion} with
-   * {@link HttpVersion#HTTP_1_1}.</li>
-   * <li>Redirects are disabled using {@link ClientPNames#HANDLE_REDIRECTS}.</li>
-   * <li>{@link ConnManagerParams#setTimeout} and {@link HttpConnectionParams#setConnectionTimeout}
-   * are set on each request based on {@link HttpRequest#getConnectTimeout()}.</li>
-   * <li>{@link HttpConnectionParams#setSoTimeout} is set on each request based on
-   * {@link HttpRequest#getReadTimeout()}.</li>
-   * </ul>
-   *
-   * <p>
-   * Use {@link Builder} for a more user-friendly way to modify the HTTP client options.
-   * </p>
-   *
-   * @param httpClient Apache HTTP client to use
-   *
-   * @since 1.6
-   */
-  public ApacheHttpTransport(HttpClient httpClient) {
-    this.httpClient = httpClient;
-    HttpParams params = httpClient.getParams();
-    HttpProtocolParams.setVersion(params, HttpVersion.HTTP_1_1);
-    params.setBooleanParameter(ClientPNames.HANDLE_REDIRECTS, false);
-  }
-
-  /**
-   * Creates a new instance of the Apache HTTP client that is used by the
-   * {@link #ApacheHttpTransport()} constructor.
-   *
-   * <p>
-   * Use this constructor if you want to customize the default Apache HTTP client. Settings:
-   * </p>
-   * <ul>
-   * <li>The client connection manager is set to {@link ThreadSafeClientConnManager}.</li>
-   * <li>The socket buffer size is set to 8192 using
-   * {@link HttpConnectionParams#setSocketBufferSize}.</li>
-   * <li><The retry mechanism is turned off by setting
-   * {@code new DefaultHttpRequestRetryHandler(0, false)}.</li>
-   * <li>The route planner uses {@link ProxySelectorRoutePlanner} with
-   * {@link ProxySelector#getDefault()}, which uses the proxy settings from <a
-   * href="http://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html">system
-   * properties</a>.</li>
-   * </ul>
-   *
-   * @return new instance of the Apache HTTP client
-   * @since 1.6
-   */
-  public static DefaultHttpClient newDefaultHttpClient() {
-    return newDefaultHttpClient(
-        SSLSocketFactory.getSocketFactory(), newDefaultHttpParams(), ProxySelector.getDefault());
-  }
-
-  /** Returns a new instance of the default HTTP parameters we use. */
-  static HttpParams newDefaultHttpParams() {
-    HttpParams params = new BasicHttpParams();
-    // Turn off stale checking. Our connections break all the time anyway,
-    // and it's not worth it to pay the penalty of checking every time.
-    HttpConnectionParams.setStaleCheckingEnabled(params, false);
-    HttpConnectionParams.setSocketBufferSize(params, 8192);
-    ConnManagerParams.setMaxTotalConnections(params, 200);
-    ConnManagerParams.setMaxConnectionsPerRoute(params, new ConnPerRouteBean(20));
-    return params;
-  }
-
-  /**
-   * Creates a new instance of the Apache HTTP client that is used by the
-   * {@link #ApacheHttpTransport()} constructor.
-   *
-   * @param socketFactory SSL socket factory
-   * @param params HTTP parameters
-   * @param proxySelector HTTP proxy selector to use {@link ProxySelectorRoutePlanner} or
-   *        {@code null} for {@link DefaultHttpRoutePlanner}
-   * @return new instance of the Apache HTTP client
-   */
-  static DefaultHttpClient newDefaultHttpClient(
-      SSLSocketFactory socketFactory, HttpParams params, ProxySelector proxySelector) {
-    // See http://hc.apache.org/httpcomponents-client-ga/tutorial/html/connmgmt.html
-    SchemeRegistry registry = new SchemeRegistry();
-    registry.register(new Scheme("http", PlainSocketFactory.getSocketFactory(), 80));
-    registry.register(new Scheme("https", socketFactory, 443));
-    ClientConnectionManager connectionManager = new ThreadSafeClientConnManager(params, registry);
-    DefaultHttpClient defaultHttpClient = new DefaultHttpClient(connectionManager, params);
-    defaultHttpClient.setHttpRequestRetryHandler(new DefaultHttpRequestRetryHandler(0, false));
-    if (proxySelector != null) {
-      defaultHttpClient.setRoutePlanner(new ProxySelectorRoutePlanner(registry, proxySelector));
-    }
-    return defaultHttpClient;
-  }
-
-  @Override
-  public boolean supportsMethod(String method) {
-    return true;
-  }
-
-  @Override
-  protected ApacheHttpRequest buildRequest(String method, String url) {
-    HttpRequestBase requestBase;
-    if (method.equals(HttpMethods.DELETE)) {
-      requestBase = new HttpDelete(url);
-    } else if (method.equals(HttpMethods.GET)) {
-      requestBase = new HttpGet(url);
-    } else if (method.equals(HttpMethods.HEAD)) {
-      requestBase = new HttpHead(url);
-    } else if (method.equals(HttpMethods.POST)) {
-      requestBase = new HttpPost(url);
-    } else if (method.equals(HttpMethods.PUT)) {
-      requestBase = new HttpPut(url);
-    } else if (method.equals(HttpMethods.TRACE)) {
-      requestBase = new HttpTrace(url);
-    } else if (method.equals(HttpMethods.OPTIONS)) {
-      requestBase = new HttpOptions(url);
-    } else {
-      requestBase = new HttpExtensionMethod(method, url);
-    }
-    return new ApacheHttpRequest(httpClient, requestBase);
-  }
-
-  /**
-   * Shuts down the connection manager and releases allocated resources. This includes closing all
-   * connections, whether they are currently used or not.
-   *
-   * @since 1.4
-   */
-  @Override
-  public void shutdown() {
-    httpClient.getConnectionManager().shutdown();
-  }
-
-  /**
-   * Returns the Apache HTTP client.
-   *
-   * @since 1.5
-   */
-  public HttpClient getHttpClient() {
-    return httpClient;
-  }
-
-  /**
-   * Builder for {@link ApacheHttpTransport}.
-   *
-   * <p>
-   * Implementation is not thread-safe.
-   * </p>
-   *
-   * @since 1.13
-   */
-  public static final class Builder {
-
-    /** SSL socket factory. */
-    private SSLSocketFactory socketFactory = SSLSocketFactory.getSocketFactory();
-
-    /** HTTP parameters. */
-    private HttpParams params = newDefaultHttpParams();
+public final class ApacheHttpTransport extends HttpTransport
+{
 
     /**
-     * HTTP proxy selector to use {@link ProxySelectorRoutePlanner} or {@code null} for
-     * {@link DefaultHttpRoutePlanner}.
-     */
-    private ProxySelector proxySelector = ProxySelector.getDefault();
-
-    /**
-     * Sets the HTTP proxy to use {@link DefaultHttpRoutePlanner} or {@code null} to use
-     * {@link #setProxySelector(ProxySelector)} with {@link ProxySelector#getDefault()}.
-     *
+     * Creates a new instance of the Apache HTTP client that is used by the
+     * {@link #ApacheHttpTransport()} constructor.
+     * <p/>
      * <p>
-     * By default it is {@code null}, which uses the proxy settings from <a
+     * Use this constructor if you want to customize the default Apache HTTP client. Settings:
+     * </p>
+     * <ul>
+     * <li>The client connection manager is set to {@link ThreadSafeClientConnManager}.</li>
+     * <li>The socket buffer size is set to 8192 using
+     * {@link HttpConnectionParams#setSocketBufferSize}.</li>
+     * <li><The retry mechanism is turned off by setting
+     * {@code new DefaultHttpRequestRetryHandler(0, false)}.</li>
+     * <li>The route planner uses {@link ProxySelectorRoutePlanner} with
+     * {@link ProxySelector#getDefault()}, which uses the proxy settings from <a
      * href="http://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html">system
-     * properties</a>.
-     * </p>
+     * properties</a>.</li>
+     * </ul>
      *
-     * <p>
-     * For example:
-     * </p>
-     *
-     * <pre>
-       setProxy(new HttpHost("127.0.0.1", 8080))
-     * </pre>
+     * @return new instance of the Apache HTTP client
+     * @since 1.6
      */
-    public Builder setProxy(HttpHost proxy) {
-      ConnRouteParams.setDefaultProxy(params, proxy);
-      if (proxy != null) {
-        proxySelector = null;
-      }
-      return this;
+    public static DefaultHttpClient newDefaultHttpClient()
+    {
+        return newDefaultHttpClient(
+                SSLSocketFactory.getSocketFactory(), newDefaultHttpParams(), ProxySelector.getDefault());
     }
 
     /**
-     * Sets the HTTP proxy selector to use {@link ProxySelectorRoutePlanner} or {@code null} for
-     * {@link DefaultHttpRoutePlanner}.
-     *
-     * <p>
-     * By default it is {@link ProxySelector#getDefault()} which uses the proxy settings from <a
-     * href="http://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html">system
-     * properties</a>.
-     * </p>
+     * Apache HTTP client.
      */
-    public Builder setProxySelector(ProxySelector proxySelector) {
-      this.proxySelector = proxySelector;
-      if (proxySelector != null) {
-        ConnRouteParams.setDefaultProxy(params, null);
-      }
-      return this;
-    }
+    private final HttpClient httpClient;
+
     /**
-     * Sets the SSL socket factory based on root certificates in a Java KeyStore.
-     *
+     * Constructor that uses {@link #newDefaultHttpClient()} for the Apache HTTP client.
+     * <p/>
      * <p>
-     * Example usage:
+     * Use {@link Builder} to modify HTTP client options.
      * </p>
      *
-     * <pre>
-    trustCertificatesFromJavaKeyStore(new FileInputStream("certs.jks"), "password");
-     * </pre>
-     *
-     * @param keyStoreStream input stream to the key store (closed at the end of this method in a
-     *        finally block)
-     * @param storePass password protecting the key store file
-     * @since 1.14
+     * @since 1.3
      */
-    public Builder trustCertificatesFromJavaKeyStore(InputStream keyStoreStream, String storePass)
-        throws GeneralSecurityException, IOException {
-      KeyStore trustStore = SecurityUtils.getJavaKeyStore();
-      SecurityUtils.loadKeyStore(trustStore, keyStoreStream, storePass);
-      return trustCertificates(trustStore);
+    public ApacheHttpTransport()
+    {
+        this(newDefaultHttpClient());
     }
 
     /**
-     * Sets the SSL socket factory based root certificates generated from the specified stream using
-     * {@link CertificateFactory#generateCertificates(InputStream)}.
-     *
+     * Constructor that allows an alternative Apache HTTP client to be used.
+     * <p/>
      * <p>
-     * Example usage:
+     * Note that a few settings are overridden:
+     * </p>
+     * <ul>
+     * <li>HTTP version is set to 1.1 using {@link HttpProtocolParams#setVersion} with
+     * {@link HttpVersion#HTTP_1_1}.</li>
+     * <li>Redirects are disabled using {@link ClientPNames#HANDLE_REDIRECTS}.</li>
+     * <li>{@link ConnManagerParams#setTimeout} and {@link HttpConnectionParams#setConnectionTimeout}
+     * are set on each request based on {@link HttpRequest#getConnectTimeout()}.</li>
+     * <li>{@link HttpConnectionParams#setSoTimeout} is set on each request based on
+     * {@link HttpRequest#getReadTimeout()}.</li>
+     * </ul>
+     * <p/>
+     * <p>
+     * Use {@link Builder} for a more user-friendly way to modify the HTTP client options.
      * </p>
      *
-     * <pre>
-    trustCertificatesFromStream(new FileInputStream("certs.pem"));
-     * </pre>
-     *
-     * @param certificateStream certificate stream
-     * @since 1.14
+     * @param httpClient Apache HTTP client to use
+     * @since 1.6
      */
-    public Builder trustCertificatesFromStream(InputStream certificateStream)
-        throws GeneralSecurityException, IOException {
-      KeyStore trustStore = SecurityUtils.getJavaKeyStore();
-      trustStore.load(null, null);
-      SecurityUtils.loadKeyStoreFromCertificates(
-          trustStore, SecurityUtils.getX509CertificateFactory(), certificateStream);
-      return trustCertificates(trustStore);
+    public ApacheHttpTransport(HttpClient httpClient)
+    {
+        this.httpClient = httpClient;
     }
 
     /**
-     * Sets the SSL socket factory based on a root certificate trust store.
-     *
-     * @param trustStore certificate trust store (use for example {@link SecurityUtils#loadKeyStore}
-     *        or {@link SecurityUtils#loadKeyStoreFromCertificates})
-     *
-     * @since 1.14
+     * Returns a new instance of the default HTTP parameters we use.
      */
-    public Builder trustCertificates(KeyStore trustStore) throws GeneralSecurityException {
-      SSLContext sslContext = SslUtils.getTlsSslContext();
-      SslUtils.initSslContext(sslContext, trustStore, SslUtils.getPkixTrustManagerFactory());
-      return setSocketFactory(new SSLSocketFactoryExtension(sslContext));
+    static HttpParams newDefaultHttpParams()
+    {
+        HttpParams params = new BasicHttpParams();
+        // Turn off stale checking. Our connections break all the time anyway,
+        // and it's not worth it to pay the penalty of checking every time.
+        HttpConnectionParams.setStaleCheckingEnabled(params, false);
+        HttpConnectionParams.setSocketBufferSize(params, 8192);
+        ConnManagerParams.setMaxTotalConnections(params, 200);
+        ConnManagerParams.setMaxConnectionsPerRoute(params, new ConnPerRouteBean(20));
+        return params;
     }
 
     /**
-     * {@link Beta} <br/>
-     * Disables validating server SSL certificates by setting the SSL socket factory using
-     * {@link SslUtils#trustAllSSLContext()} for the SSL context and
-     * {@link SSLSocketFactory#ALLOW_ALL_HOSTNAME_VERIFIER} for the host name verifier.
+     * Creates a new instance of the Apache HTTP client that is used by the
+     * {@link #ApacheHttpTransport()} constructor.
      *
-     * <p>
-     * Be careful! Disabling certificate validation is dangerous and should only be done in testing
-     * environments.
-     * </p>
+     * @param socketFactory SSL socket factory
+     * @param params        HTTP parameters
+     * @param proxySelector HTTP proxy selector to use {@link ProxySelectorRoutePlanner} or
+     *                      {@code null} for {@link DefaultHttpRoutePlanner}
+     * @return new instance of the Apache HTTP client
      */
-    @Beta
-    public Builder doNotValidateCertificate() throws GeneralSecurityException {
-      socketFactory = new SSLSocketFactoryExtension(SslUtils.trustAllSSLContext());
-      socketFactory.setHostnameVerifier(SSLSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
-      return this;
+    static DefaultHttpClient newDefaultHttpClient(
+            SSLSocketFactory socketFactory, HttpParams params, ProxySelector proxySelector)
+    {
+        // See http://hc.apache.org/httpcomponents-client-ga/tutorial/html/connmgmt.html
+        SchemeRegistry registry = new SchemeRegistry();
+        registry.register(new Scheme("http", PlainSocketFactory.getSocketFactory(), 80));
+        registry.register(new Scheme("https", socketFactory, 443));
+        ClientConnectionManager connectionManager = new ThreadSafeClientConnManager(params, registry);
+        DefaultHttpClient defaultHttpClient = new DefaultHttpClient(connectionManager, params);
+        defaultHttpClient.setHttpRequestRetryHandler(new DefaultHttpRequestRetryHandler(0, false));
+        if (proxySelector != null)
+        {
+            defaultHttpClient.setRoutePlanner(new ProxySelectorRoutePlanner(registry, proxySelector));
+        }
+        return defaultHttpClient;
     }
 
-    /** Sets the SSL socket factory ({@link SSLSocketFactory#getSocketFactory()} by default). */
-    public Builder setSocketFactory(SSLSocketFactory socketFactory) {
-      this.socketFactory = Preconditions.checkNotNull(socketFactory);
-      return this;
+    @Override
+    public boolean supportsMethod(String method)
+    {
+        return true;
     }
 
-    /** Returns the SSL socket factory ({@link SSLSocketFactory#getSocketFactory()} by default). */
-    public SSLSocketFactory getSSLSocketFactory() {
-      return socketFactory;
+    @Override
+    protected ApacheHttpRequest buildRequest(String method, String url)
+    {
+        HttpRequestBase requestBase;
+        if (method.equals(HttpMethods.DELETE))
+        {
+            requestBase = new HttpDelete(url);
+        }
+        else if (method.equals(HttpMethods.GET))
+        {
+            requestBase = new HttpGet(url);
+        }
+        else if (method.equals(HttpMethods.HEAD))
+        {
+            requestBase = new HttpHead(url);
+        }
+        else if (method.equals(HttpMethods.POST))
+        {
+            requestBase = new HttpPost(url);
+        }
+        else if (method.equals(HttpMethods.PUT))
+        {
+            requestBase = new HttpPut(url);
+        }
+        else if (method.equals(HttpMethods.TRACE))
+        {
+            requestBase = new HttpTrace(url);
+        }
+        else if (method.equals(HttpMethods.OPTIONS))
+        {
+            requestBase = new HttpOptions(url);
+        }
+        else
+        {
+            requestBase = new HttpExtensionMethod(method, url);
+        }
+        return new ApacheHttpRequest(httpClient, requestBase);
     }
 
-    /** Returns the HTTP parameters. */
-    public HttpParams getHttpParams() {
-      return params;
+    /**
+     * Shuts down the connection manager and releases allocated resources. This includes closing all
+     * connections, whether they are currently used or not.
+     *
+     * @since 1.4
+     */
+    @Override
+    public void shutdown()
+    {
+        httpClient.getConnectionManager().shutdown();
     }
 
-    /** Returns a new instance of {@link ApacheHttpTransport} based on the options. */
-    public ApacheHttpTransport build() {
-      return new ApacheHttpTransport(newDefaultHttpClient(socketFactory, params, proxySelector));
+    /**
+     * Returns the Apache HTTP client.
+     *
+     * @since 1.5
+     */
+    public HttpClient getHttpClient()
+    {
+        return httpClient;
     }
-  }
+
+    /**
+     * Builder for {@link ApacheHttpTransport}.
+     * <p/>
+     * <p>
+     * Implementation is not thread-safe.
+     * </p>
+     *
+     * @since 1.13
+     */
+    public static final class Builder
+    {
+
+        /**
+         * SSL socket factory.
+         */
+        private SSLSocketFactory socketFactory = SSLSocketFactory.getSocketFactory();
+
+        /**
+         * HTTP parameters.
+         */
+        private HttpParams params = newDefaultHttpParams();
+
+        /**
+         * HTTP proxy selector to use {@link ProxySelectorRoutePlanner} or {@code null} for
+         * {@link DefaultHttpRoutePlanner}.
+         */
+        private ProxySelector proxySelector = ProxySelector.getDefault();
+
+        /**
+         * Sets the HTTP proxy to use {@link DefaultHttpRoutePlanner} or {@code null} to use
+         * {@link #setProxySelector(ProxySelector)} with {@link ProxySelector#getDefault()}.
+         * <p/>
+         * <p>
+         * By default it is {@code null}, which uses the proxy settings from <a
+         * href="http://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html">system
+         * properties</a>.
+         * </p>
+         * <p/>
+         * <p>
+         * For example:
+         * </p>
+         * <p/>
+         * <pre>
+         * setProxy(new HttpHost("127.0.0.1", 8080))
+         * </pre>
+         */
+        public Builder setProxy(HttpHost proxy)
+        {
+            ConnRouteParams.setDefaultProxy(params, proxy);
+            if (proxy != null)
+            {
+                proxySelector = null;
+            }
+            return this;
+        }
+
+        /**
+         * Sets the HTTP proxy selector to use {@link ProxySelectorRoutePlanner} or {@code null} for
+         * {@link DefaultHttpRoutePlanner}.
+         * <p/>
+         * <p>
+         * By default it is {@link ProxySelector#getDefault()} which uses the proxy settings from <a
+         * href="http://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html">system
+         * properties</a>.
+         * </p>
+         */
+        public Builder setProxySelector(ProxySelector proxySelector)
+        {
+            this.proxySelector = proxySelector;
+            if (proxySelector != null)
+            {
+                ConnRouteParams.setDefaultProxy(params, null);
+            }
+            return this;
+        }
+
+        /**
+         * Sets the SSL socket factory based on root certificates in a Java KeyStore.
+         * <p/>
+         * <p>
+         * Example usage:
+         * </p>
+         * <p/>
+         * <pre>
+         * trustCertificatesFromJavaKeyStore(new FileInputStream("certs.jks"), "password");
+         * </pre>
+         *
+         * @param keyStoreStream input stream to the key store (closed at the end of this method in a
+         *                       finally block)
+         * @param storePass      password protecting the key store file
+         * @since 1.14
+         */
+        public Builder trustCertificatesFromJavaKeyStore(InputStream keyStoreStream, String storePass)
+                throws GeneralSecurityException, IOException
+        {
+            KeyStore trustStore = SecurityUtils.getJavaKeyStore();
+            SecurityUtils.loadKeyStore(trustStore, keyStoreStream, storePass);
+            return trustCertificates(trustStore);
+        }
+
+        /**
+         * Sets the SSL socket factory based root certificates generated from the specified stream using
+         * {@link CertificateFactory#generateCertificates(InputStream)}.
+         * <p/>
+         * <p>
+         * Example usage:
+         * </p>
+         * <p/>
+         * <pre>
+         * trustCertificatesFromStream(new FileInputStream("certs.pem"));
+         * </pre>
+         *
+         * @param certificateStream certificate stream
+         * @since 1.14
+         */
+        public Builder trustCertificatesFromStream(InputStream certificateStream)
+                throws GeneralSecurityException, IOException
+        {
+            KeyStore trustStore = SecurityUtils.getJavaKeyStore();
+            trustStore.load(null, null);
+            SecurityUtils.loadKeyStoreFromCertificates(
+                    trustStore, SecurityUtils.getX509CertificateFactory(), certificateStream);
+            return trustCertificates(trustStore);
+        }
+
+        /**
+         * Sets the SSL socket factory based on a root certificate trust store.
+         *
+         * @param trustStore certificate trust store (use for example {@link SecurityUtils#loadKeyStore}
+         *                   or {@link SecurityUtils#loadKeyStoreFromCertificates})
+         * @since 1.14
+         */
+        public Builder trustCertificates(KeyStore trustStore) throws GeneralSecurityException
+        {
+            SSLContext sslContext = SslUtils.getTlsSslContext();
+            SslUtils.initSslContext(sslContext, trustStore, SslUtils.getPkixTrustManagerFactory());
+            return setSocketFactory(new SSLSocketFactoryExtension(sslContext));
+        }
+
+        /**
+         * {@link Beta} <br/>
+         * Disables validating server SSL certificates by setting the SSL socket factory using
+         * {@link SslUtils#trustAllSSLContext()} for the SSL context and
+         * {@link SSLSocketFactory#ALLOW_ALL_HOSTNAME_VERIFIER} for the host name verifier.
+         * <p/>
+         * <p>
+         * Be careful! Disabling certificate validation is dangerous and should only be done in testing
+         * environments.
+         * </p>
+         */
+        @Beta
+        public Builder doNotValidateCertificate() throws GeneralSecurityException
+        {
+            socketFactory = new SSLSocketFactoryExtension(SslUtils.trustAllSSLContext());
+            socketFactory.setHostnameVerifier(SSLSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
+            return this;
+        }
+
+        /**
+         * Sets the SSL socket factory ({@link SSLSocketFactory#getSocketFactory()} by default).
+         */
+        public Builder setSocketFactory(SSLSocketFactory socketFactory)
+        {
+            this.socketFactory = Preconditions.checkNotNull(socketFactory);
+            return this;
+        }
+
+        /**
+         * Returns the SSL socket factory ({@link SSLSocketFactory#getSocketFactory()} by default).
+         */
+        public SSLSocketFactory getSSLSocketFactory()
+        {
+            return socketFactory;
+        }
+
+        /**
+         * Returns the HTTP parameters.
+         */
+        public HttpParams getHttpParams()
+        {
+            return params;
+        }
+
+        /**
+         * Returns a new instance of {@link ApacheHttpTransport} based on the options.
+         */
+        public ApacheHttpTransport build()
+        {
+            return new ApacheHttpTransport(newDefaultHttpClient(socketFactory, params, proxySelector));
+        }
+    }
 }

--- a/google-http-client/src/main/java/com/google/api/client/http/apache/ContentEntity.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/apache/ContentEntity.java
@@ -14,6 +14,7 @@
 
 package com.google.api.client.http.apache;
 
+import com.google.api.client.http.HttpContent;
 import com.google.api.client.util.Preconditions;
 import com.google.api.client.util.StreamingContent;
 
@@ -38,7 +39,7 @@ final class ContentEntity extends AbstractHttpEntity {
    * @param contentLength content length or less than zero if not known
    * @param streamingContent streaming content
    */
-  ContentEntity(long contentLength, StreamingContent streamingContent) {
+  ContentEntity(final long contentLength, final StreamingContent streamingContent) {
     this.contentLength = contentLength;
     this.streamingContent = Preconditions.checkNotNull(streamingContent);
   }
@@ -52,7 +53,7 @@ final class ContentEntity extends AbstractHttpEntity {
   }
 
   public boolean isRepeatable() {
-    return false;
+    return this.streamingContent instanceof HttpContent && ((HttpContent)this.streamingContent).retrySupported();
   }
 
   public boolean isStreaming() {

--- a/google-http-client/src/main/java/com/google/api/client/http/json/JsonHttpContent.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/json/JsonHttpContent.java
@@ -82,6 +82,11 @@ public class JsonHttpContent extends AbstractHttpContent {
     generator.flush();
   }
 
+  public boolean retrySupported()
+  {
+    return true;
+  }
+
   @Override
   public JsonHttpContent setMediaType(HttpMediaType mediaType) {
     super.setMediaType(mediaType);

--- a/google-http-client/src/main/java/com/google/api/client/util/ByteArrayStreamingContent.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/ByteArrayStreamingContent.java
@@ -61,4 +61,9 @@ public class ByteArrayStreamingContent implements StreamingContent {
     out.write(byteArray, offset, length);
     out.flush();
   }
+
+  public boolean retrySupported()
+  {
+    return true;
+  }
 }

--- a/google-http-client/src/main/java/com/google/api/client/util/LoggingStreamingContent.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/LoggingStreamingContent.java
@@ -69,4 +69,9 @@ public final class LoggingStreamingContent implements StreamingContent {
     }
     out.flush();
   }
+
+  public boolean retrySupported()
+  {
+    return false;
+  }
 }

--- a/instructions.html
+++ b/instructions.html
@@ -18,16 +18,14 @@
   href="http://maven.apache.org/download.html">Maven</a>. You may need to set
 your <code>JAVA_HOME</code>.</p>
 
-<pre><code>hg clone https://google-api-java-client.googlecode.com/hg/ google-api-java-client
+<pre><code>git clone https://github.com/google/google-http-java-client.git
 cd google-api-java-client
 mvn install</code></pre>
 
-There are two named branches:
+There are a few named branches:
 <ul>
-  <li>The "default" branch has the stable 1.4 library. This is the default
-  branch that is checked out with the instructions above.</li>
-  <li>The "dev" branch has the development 1.5 library. To switch to this
-  branch, run: <pre><code>hg update dev
+  <li>The "master" branch has the development of the next release. To switch to this
+  branch, run: <pre><code>git checkout master
 mvn clean install</code></pre></li>
 </ul>
 


### PR DESCRIPTION
I fixed this temporarily so that I could get it to work with Apache HttpClient 4.5.1

All the `.getParams()` calls need to be migrated to `RequestConfig` instead as `.getParams()` is deprecated and now throws an `UnsupportedOperationException` I do not have time to explore refactoring to use `RequestConfig` at the moment so this small change stops the exception and lets me get on to doing what I need to do.

You can see why this is breaking based on [this question on stackoverflow](http://stackoverflow.com/questions/33761536/nt-authentication-with-googlehttpclient)
