### PR TITLE
Preferred implementation in comments was hard to find

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/http/HttpTransport.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpTransport.java
@@ -52,8 +52,10 @@ import java.util.logging.Logger;
  * </li>
  * <li>Other Java environments
  * <ul>
+ * <li>{@code com.google.api.client.googleapis.javanet.GoogleNetHttpTransport} is included in
+ * google-api-cient 1.22.0, so easy to include.</li>
  * <li>{@code com.google.api.client.javanet.NetHttpTransport} is based on the HttpURLConnection
- * built into the Java SDK, so it is normally the preferred choice.</li>
+ * built into the Java SDK, so it used to be the preferred choice.</li>
  * <li>{@code com.google.api.client.apache.ApacheHttpTransport} is a good choice for users of the
  * Apache HTTP Client, especially if you need some of the configuration options available in that
  * library.</li>


### PR DESCRIPTION
The example here:
https://developers.google.com/identity/sign-in/web/backend-auth
Shows:
new GoogleIdTokenVerifier.Builder(transport, jsonFactory)
But doesn't show where the transport or jsonFactory come from.

It was easy to find the right JSON library from the left-nav here:
https://developers.google.com/api-client-library/java/google-http-java-client/setup

But it was not so easy to find a HTTPTransport from that page or from the Javadoc here:
https://github.com/google/google-http-java-client/blob/dev/google-http-client/src/main/java/com/google/api/client/http/HttpTransport.java

Both those sources suggested that plain old Java projects use com.google.api.client.javanet.NetHttpTransport which I could not find.  But com.google.api.client.googleapis.javanet.GoogleNetHttpTransport was already included in the google-api-cient and worked for me!

The suggestion to use GoogleNetHttpTransport came from here:
https://developers.google.com/google-apps/tasks/quickstart/java#step_3_configure_the_project_build

I don't know whether it's best to update the original web page, or the comments here, or both, or if I've done something evil by including GoogleNetHttpTransport, but it works with no additional dependencies, so I thought I'd offer this documentation tweak.
