### PR TITLE
Swallow exception from close call when there is an underlying IOException

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/http/javanet/NetHttpRequest.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/javanet/NetHttpRequest.java
@@ -75,12 +75,10 @@ final class NetHttpRequest extends LowLevelHttpRequest {
           connection.setChunkedStreamingMode(0);
         }
         OutputStream out = connection.getOutputStream();
-        IOException thrown = null;
+        boolean threw = true;
         try {
           getStreamingContent().writeTo(out);
-        } catch(IOException exception) {
-          thrown = exception;
-          throw exception;
+          threw = false;
         } finally {
           try {
             out.close();
@@ -88,7 +86,7 @@ final class NetHttpRequest extends LowLevelHttpRequest {
             // When writeTo() throws an exception, chances are that the close call will also fail.
             // In such case, swallow exception from close call so that the underlying cause can
             // propagate.
-            if (thrown == null) {
+            if (!threw) {
               throw exception;
             }
           }


### PR DESCRIPTION
There have been numerous reports of users of the client library seeing IO exceptions bearing the message "insufficient data written" (google/google-api-java-client#781 google/google-api-java-client#782 GoogleCloudPlatform/google-cloud-java#1018)

I believe these error messages are misleading, and are secondary effect of attempting to close the stream when the underlying IO operation was actually failing (see [underlying close implementation](https://github.com/openjdk-mirror/jdk7u-jdk/blob/f4d80957e89a19a29bb9f9807d2a28351ed7f7df/src/share/classes/sun/net/www/protocol/http/HttpURLConnection.java#L3187)) 

Therefore I propose we handle the case when there has been an underlying IO exception error, we still attempt to close the stream but let the original IO exception propagate nonetheless.
