### PR TITLE
Update to Guava 20.0

### DIFF
--- a/google-http-client-appengine/pom.xml
+++ b/google-http-client-appengine/pom.xml
@@ -80,7 +80,7 @@
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
-      <artifactId>guava-jdk5</artifactId>
+      <artifactId>guava</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/google-http-client-gson/pom.xml
+++ b/google-http-client-gson/pom.xml
@@ -77,7 +77,7 @@
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
-      <artifactId>guava-jdk5</artifactId>
+      <artifactId>guava</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/google-http-client-jackson/pom.xml
+++ b/google-http-client-jackson/pom.xml
@@ -77,7 +77,7 @@
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
-      <artifactId>guava-jdk5</artifactId>
+      <artifactId>guava</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/google-http-client-jackson2/pom.xml
+++ b/google-http-client-jackson2/pom.xml
@@ -77,7 +77,7 @@
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
-      <artifactId>guava-jdk5</artifactId>
+      <artifactId>guava</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/google-http-client-jdo/pom.xml
+++ b/google-http-client-jdo/pom.xml
@@ -110,7 +110,7 @@
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
-      <artifactId>guava-jdk5</artifactId>
+      <artifactId>guava</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/google-http-client-test/pom.xml
+++ b/google-http-client-test/pom.xml
@@ -66,7 +66,7 @@
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
-      <artifactId>guava-jdk5</artifactId>
+      <artifactId>guava</artifactId>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/google-http-client-xml/pom.xml
+++ b/google-http-client-xml/pom.xml
@@ -71,7 +71,7 @@
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
-      <artifactId>guava-jdk5</artifactId>
+      <artifactId>guava</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/google-http-client/pom.xml
+++ b/google-http-client/pom.xml
@@ -42,7 +42,7 @@
       </plugin>
       <!-- Use jarjar to include a private copy of Apache Commons Codec library
            to avoid a runtime dependency conflict with Android which includes
-           an older version of that library, as well as Guava JDK5. -->
+           an older version of that library, as well as Guava. -->
       <plugin>
         <groupId>org.sonatype.plugins</groupId>
         <artifactId>jarjar-maven-plugin</artifactId>
@@ -55,7 +55,7 @@
             <configuration>
               <includes>
                 <include>commons-codec:commons-codec</include>
-                <include>com.google.guava:guava-jdk5</include>
+                <include>com.google.guava:guava</include>
               </includes>
               <rules>
                 <rule>
@@ -115,7 +115,7 @@
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
-      <artifactId>guava-jdk5</artifactId>
+      <artifactId>guava</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,7 @@
       </dependency>
       <dependency>
         <groupId>com.google.guava</groupId>
-        <artifactId>guava-jdk5</artifactId>
+        <artifactId>guava</artifactId>
         <version>${project.guava.version}</version>
       </dependency>
       <dependency>
@@ -609,7 +609,7 @@
     <project.jackson-core-asl.version>1.9.11</project.jackson-core-asl.version>
     <project.jackson-core2.version>2.1.3</project.jackson-core2.version>
     <project.protobuf-java.version>2.6.1</project.protobuf-java.version>
-    <project.guava.version>17.0</project.guava.version>
+    <project.guava.version>20.0</project.guava.version>
     <project.xpp3.version>1.1.4c</project.xpp3.version>
     <project.commons-logging.version>1.1.1</project.commons-logging.version>
     <project.httpclient.version>4.0.1</project.httpclient.version>


### PR DESCRIPTION
guava-jdk5 17.0 is very old: 3 years, which is beyond the supported lifetime of Guava. Additionally, guava on jdk5 is no longer supported since Java 5 has been EOL for a while.

This library depending on a very old version of guava was first reported here: https://github.com/google/dagger/issues/651

I don't know what to do with the files in `google-http-client-assembly/dependencies/` but those look to be out of date anyway.

Note that I didn't update to Guava 21, since that version requires Java 8.