### PR TITLE
Fixing ArrayMap hashCode to work with null values

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/util/ArrayMap.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/ArrayMap.java
@@ -416,7 +416,9 @@ public class ArrayMap<K, V> extends AbstractMap<K, V> implements Cloneable {
 
     @Override
     public int hashCode() {
-      return getKey().hashCode() ^ getValue().hashCode();
+      K key = getKey();
+      V value = getValue();
+      return (key != null ? key.hashCode() : 0) ^ (value != null ? value.hashCode() : 0);
     }
 
     @Override

--- a/google-http-client/src/test/java/com/google/api/client/util/ArrayMapTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/util/ArrayMapTest.java
@@ -100,4 +100,13 @@ public class ArrayMapTest extends TestCase {
     } catch (IndexOutOfBoundsException e) {
     }
   }
+
+  public void testHashCode() {
+    ArrayMap<String, Integer> map = ArrayMap.of();
+    map.set(0, "a", null);
+    map.set(1, null, 1);
+    map.set(2, null, null);
+
+    assertTrue(map.hashCode() > 0);
+  }
 }


### PR DESCRIPTION
This should fix: https://github.com/google/google-http-java-client/issues/384

Just checking if the values are not null before calling the hash code method on them.