### PR TITLE
Enhance OpenCensus tracing instrumentation.

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/http/HttpRequest.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpRequest.java
@@ -869,14 +869,15 @@ public final class HttpRequest {
         .spanBuilder(OpenCensusUtils.SPAN_NAME_HTTP_REQUEST_EXECUTE)
         .setRecordEvents(OpenCensusUtils.isRecordEvent())
         .startSpan();
-    long idGenerator = 0L;
+    long sentIdGenerator = 0L;
+    long recvIdGenerator = 0L;
 
     do {
       span.addAnnotation(
           Annotation.fromDescriptionAndAttributes(
               "retry",
               Collections.<String, AttributeValue>singletonMap(
-                  "number of retry",
+                  "number",
                   AttributeValue.longAttributeValue(numRetries - retriesRemaining))));
       // Cleanup any unneeded response from a previous iteration
       if (response != null) {
@@ -1005,12 +1006,12 @@ public final class HttpRequest {
       // switch tracing scope to current span
       Scope ws = tracer.withSpan(span);
       OpenCensusUtils.recordSentMessageEvent(
-          span, idGenerator++, lowLevelHttpRequest.getContentLength());
+          span, sentIdGenerator++, lowLevelHttpRequest.getContentLength());
       try {
         LowLevelHttpResponse lowLevelHttpResponse = lowLevelHttpRequest.execute();
         if (lowLevelHttpResponse != null) {
           OpenCensusUtils.recordReceivedMessageEvent(
-              span, idGenerator++, lowLevelHttpResponse.getContentLength());
+              span, recvIdGenerator++, lowLevelHttpResponse.getContentLength());
         }
         // Flag used to indicate if an exception is thrown before the response is constructed.
         boolean responseConstructed = false;

--- a/google-http-client/src/main/java/com/google/api/client/util/OpenCensusUtils.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/OpenCensusUtils.java
@@ -16,7 +16,6 @@ package com.google.api.client.util;
 
 import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpRequest;
-import com.google.api.client.http.HttpResponse;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.common.annotations.VisibleForTesting;
 
@@ -31,9 +30,7 @@ import io.opencensus.trace.Tracer;
 import io.opencensus.trace.Tracing;
 import io.opencensus.trace.propagation.TextFormat;
 
-import java.io.IOException;
 import java.util.Collections;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;

--- a/google-http-client/src/main/java/com/google/api/client/util/OpenCensusUtils.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/OpenCensusUtils.java
@@ -15,12 +15,16 @@
 package com.google.api.client.util;
 
 import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpResponse;
 import com.google.api.client.http.HttpStatusCodes;
+import com.google.common.annotations.VisibleForTesting;
 
 import io.opencensus.contrib.http.util.HttpPropagationUtil;
 import io.opencensus.trace.BlankSpan;
 import io.opencensus.trace.EndSpanOptions;
+import io.opencensus.trace.NetworkEvent;
+import io.opencensus.trace.NetworkEvent.Type;
 import io.opencensus.trace.Span;
 import io.opencensus.trace.Status;
 import io.opencensus.trace.Tracer;
@@ -28,6 +32,8 @@ import io.opencensus.trace.Tracing;
 import io.opencensus.trace.propagation.TextFormat;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
@@ -43,25 +49,48 @@ public class OpenCensusUtils {
   private static final Logger LOGGER = Logger.getLogger(OpenCensusUtils.class.getName());
 
   /**
+   * Span name for tracing {@link HttpRequest#execute()}.
+   */
+  public static final String SPAN_NAME_HTTP_REQUEST_EXECUTE =
+      "Sent." + HttpRequest.class.getName() + ".execute";
+
+  /**
    * OpenCensus tracing component.
    * When no OpenCensus implementation is provided, it will return a no-op tracer.
    */
-  static Tracer tracer = Tracing.getTracer();
+  private static Tracer tracer = Tracing.getTracer();
+
+  /**
+   * Sequence id generator for message event.
+   */
+  private static AtomicLong idGenerator = new AtomicLong();
+
+  /**
+   * Whether spans should be recorded locally. Defaults to true.
+   */
+  private static volatile boolean isRecordEvent = true;
 
   /**
    * {@link TextFormat} used in tracing context propagation.
    */
   @Nullable
-  static TextFormat propagationTextFormat = null;
+  @VisibleForTesting
+  static volatile TextFormat propagationTextFormat = null;
 
   /**
-   * {@link TextFormat.Setter} for {@link activeTextFormat}.
+   * {@link TextFormat.Setter} for {@link #propagationTextFormat}.
    */
   @Nullable
-  static TextFormat.Setter propagationTextFormatSetter = null;
+  @VisibleForTesting
+  static volatile TextFormat.Setter propagationTextFormatSetter = null;
 
   /**
    * Sets the {@link TextFormat} used in context propagation.
+   *
+   * <p>This API allows users of google-http-client to specify other text format, or disable context
+   * propagation by setting it to {@code null}. It should be used along with {@link
+   * #setPropagationTextFormatSetter} for setting purpose. </p>
+   *
    * @param textFormat the text format.
    */
   public static void setPropagationTextFormat(@Nullable TextFormat textFormat) {
@@ -70,10 +99,26 @@ public class OpenCensusUtils {
 
   /**
    * Sets the {@link TextFormat.Setter} used in context propagation.
+   *
+   * <p>This API allows users of google-http-client to specify other text format setter, or disable
+   * context propagation by setting it to {@code null}. It should be used along with {@link
+   * #setPropagationTextFormat} for setting purpose. </p>
+   *
    * @param textFormatSetter the {@code TextFormat.Setter} for the text format.
    */
   public static void setPropagationTextFormatSetter(@Nullable TextFormat.Setter textFormatSetter) {
     propagationTextFormatSetter = textFormatSetter;
+  }
+
+  /**
+   * Sets whether spans should be recorded locally.
+   *
+   * <p> This API allows users of google-http-client to turn on/off local span collection. </p>
+   *
+   * @param recordEvent record span locally if true.
+   */
+  public static void setIsRecordEvent(boolean recordEvent) {
+    isRecordEvent = recordEvent;
   }
 
   /**
@@ -86,14 +131,26 @@ public class OpenCensusUtils {
   }
 
   /**
+   * Returns whether spans should be recorded locally.
+   *
+   * @return whether spans should be recorded locally.
+   */
+  public static boolean isRecordEvent() {
+    return isRecordEvent;
+  }
+
+  /**
    * Propagate information of current tracing context. This information will be injected into HTTP
    * header.
+   *
+   * @param span the span to be propagated.
+   * @param headers the headers used in propagation.
    */
-  public static void propagateTracingContext(HttpHeaders headers) {
-    Preconditions.checkNotNull(headers);
+  public static void propagateTracingContext(Span span, HttpHeaders headers) {
+    Preconditions.checkArgument(span != null, "span should not be null.");
+    Preconditions.checkArgument(headers != null, "headers should not be null.");
     if (propagationTextFormat != null && propagationTextFormatSetter != null) {
-      Span span = tracer.getCurrentSpan();
-      if (span != null && !span.equals(BlankSpan.INSTANCE)) {
+      if (!span.equals(BlankSpan.INSTANCE)) {
         propagationTextFormat.inject(span.getContext(), headers, propagationTextFormatSetter);
       }
     }
@@ -107,7 +164,7 @@ public class OpenCensusUtils {
    */
   public static EndSpanOptions getEndSpanOptions(@Nullable Integer statusCode) {
     // Always sample the span, but optionally export it.
-    EndSpanOptions.Builder builder = EndSpanOptions.builder().setSampleToLocalSpanStore(true);
+    EndSpanOptions.Builder builder = EndSpanOptions.builder();
     if (statusCode == null) {
       builder.setStatus(Status.UNKNOWN);
     } else if (!HttpStatusCodes.isSuccess(statusCode)) {
@@ -139,6 +196,48 @@ public class OpenCensusUtils {
     return builder.build();
   }
 
+  /**
+   * Records a new message event which contains the size of the request content.
+   * Note that the size represents the message size in application layer, i.e., content-length.
+   *
+   * @param span The {@code span} in which the send event occurs.
+   * @param size Size of the request.
+   */
+  public static void recordSentMessageEvent(Span span, long size) {
+    recordMessageEvent(span, size, Type.SENT);
+  }
+
+  /**
+   * Records a new message event which contains the size of the response content.
+   * Note that the size represents the message size in application layer, i.e., content-length.
+   *
+   * @param span The {@code span} in which the receive event occurs.
+   * @param size Size of the response.
+   */
+  public static void recordReceivedMessageEvent(Span span, long size) {
+    recordMessageEvent(span, size, Type.RECV);
+  }
+
+  /**
+   * Records a message event of a certain {@link NetowrkEvent.Type}.
+   * This method is package protected since {@link NetworkEvent} might be deprecated in future
+   * releases.
+   *
+   * @param span The {@code span} in which the event occurs.
+   * @param size Size of the message.
+   * @param eventType The {@code NetworkEvent.Type} of the message event.
+   */
+  @VisibleForTesting
+  static void recordMessageEvent(Span span, long size, Type eventType) {
+    Preconditions.checkArgument(span != null, "span should not be null.");
+    if (size < 0) size = 0;
+    NetworkEvent event = NetworkEvent
+        .builder(eventType, idGenerator.getAndIncrement())
+        .setUncompressedMessageSize(size)
+        .build();
+    span.addNetworkEvent(event);
+  }
+
   static {
     try {
       propagationTextFormat = HttpPropagationUtil.getCloudTraceFormat();
@@ -149,7 +248,16 @@ public class OpenCensusUtils {
         }
       };
     } catch (Exception e) {
-      LOGGER.log(Level.WARNING, "Cannot initiate OpenCensus modules, tracing disabled", e);
+      LOGGER.log(
+          Level.WARNING, "Cannot initialize default OpenCensus HTTP propagation text format.", e);
+    }
+
+    try {
+      Tracing.getExportComponent().getSampledSpanStore().registerSpanNamesForCollection(
+          Collections.<String>singletonList(SPAN_NAME_HTTP_REQUEST_EXECUTE));
+    } catch (Exception e) {
+      LOGGER.log(
+          Level.WARNING, "Cannot register default OpenCensus span names for collection.", e);
     }
   }
 

--- a/google-http-client/src/test/java/com/google/api/client/util/OpenCensusUtilsTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/util/OpenCensusUtilsTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.verify;
 import com.google.api.client.http.HttpHeaders;
 
 import io.opencensus.trace.EndSpanOptions;
-import io.opencensus.trace.AttributeValue;
 import io.opencensus.trace.NetworkEvent;
 import io.opencensus.trace.Span;
 import io.opencensus.trace.SpanId;

--- a/google-http-client/src/test/java/com/google/api/client/util/OpenCensusUtilsTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/util/OpenCensusUtilsTest.java
@@ -16,18 +16,22 @@ package com.google.api.client.util;
 
 import com.google.api.client.http.HttpHeaders;
 
-import io.opencensus.common.Scope;
+import io.opencensus.trace.BlankSpan;
 import io.opencensus.trace.EndSpanOptions;
+import io.opencensus.trace.Annotation;
+import io.opencensus.trace.AttributeValue;
+import io.opencensus.trace.Link;
+import io.opencensus.trace.NetworkEvent;
 import io.opencensus.trace.Span;
 import io.opencensus.trace.SpanContext;
 import io.opencensus.trace.Status;
 import io.opencensus.trace.Tracer;
 import io.opencensus.trace.propagation.TextFormat;
 import java.util.List;
+import java.util.Map;
 import junit.framework.TestCase;
 import org.junit.Assert;
 import org.junit.Rule;
-import org.junit.rules.ExpectedException;
 
 /**
  * Tests {@link OpenCensusUtils}.
@@ -36,9 +40,11 @@ import org.junit.rules.ExpectedException;
  */
 public class OpenCensusUtilsTest extends TestCase {
 
-  @Rule public ExpectedException thrown = ExpectedException.none();
   TextFormat mockTextFormat;
   TextFormat.Setter mockTextFormatSetter;
+  TextFormat originTextFormat;
+  TextFormat.Setter originTextFormatSetter;
+  Span mockSpan;
   HttpHeaders headers;
   Tracer tracer;
 
@@ -48,7 +54,7 @@ public class OpenCensusUtilsTest extends TestCase {
 
   @Override
   public void setUp() {
-    TextFormat mockTextFormat = new TextFormat() {
+    mockTextFormat = new TextFormat() {
       @Override
       public List<String> fields() {
         throw new UnsupportedOperationException("TextFormat.fields");
@@ -64,7 +70,7 @@ public class OpenCensusUtilsTest extends TestCase {
         throw new UnsupportedOperationException("TextFormat.extract");
       }
     };
-    TextFormat.Setter mockTextFormatSetter = new TextFormat.Setter<HttpHeaders>() {
+    mockTextFormatSetter = new TextFormat.Setter<HttpHeaders>() {
       @Override
       public void put(HttpHeaders carrier, String key, String value) {
         throw new UnsupportedOperationException("TextFormat.Setter.put");
@@ -72,6 +78,33 @@ public class OpenCensusUtilsTest extends TestCase {
     };
     headers = new HttpHeaders();
     tracer = OpenCensusUtils.getTracer();
+    mockSpan = new Span(tracer.getCurrentSpan().getContext(), null) {
+
+      @Override
+      public void addAnnotation(String description, Map<String, AttributeValue> attributes) {}
+
+      @Override
+      public void addAnnotation(Annotation annotation) {}
+
+      @Override
+      public void addNetworkEvent(NetworkEvent event) {
+        throw new UnsupportedOperationException("Span.addNetworkEvent");
+      }
+
+      @Override
+      public void addLink(Link link) {}
+
+      @Override
+      public void end(EndSpanOptions options) {}
+    };
+    originTextFormat = OpenCensusUtils.propagationTextFormat;
+    originTextFormatSetter = OpenCensusUtils.propagationTextFormatSetter;
+  }
+
+  @Override
+  public void tearDown() {
+    OpenCensusUtils.setPropagationTextFormat(originTextFormat);
+    OpenCensusUtils.setPropagationTextFormatSetter(originTextFormatSetter);
   }
 
   public void testInitializatoin() {
@@ -92,108 +125,115 @@ public class OpenCensusUtilsTest extends TestCase {
 
   public void testPropagateTracingContextInjection() {
     OpenCensusUtils.setPropagationTextFormat(mockTextFormat);
-    Span span = OpenCensusUtils.getTracer().spanBuilder("test").startSpan();
-    Scope scope = OpenCensusUtils.getTracer().withSpan(span);
-    thrown.expect(UnsupportedOperationException.class);
-    thrown.expectMessage("TextFormat.inject");
-    OpenCensusUtils.propagateTracingContext(headers);
-    scope.close();
-    span.end();
+    try {
+      OpenCensusUtils.propagateTracingContext(mockSpan, headers);
+      fail("expected " + UnsupportedOperationException.class);
+    } catch (UnsupportedOperationException e) {
+      assertEquals(e.getMessage(), "TextFormat.inject");
+    }
   }
 
   public void testPropagateTracingContextHeader() {
     OpenCensusUtils.setPropagationTextFormatSetter(mockTextFormatSetter);
-    Span span = OpenCensusUtils.getTracer().spanBuilder("test").startSpan();
-    Scope scope = OpenCensusUtils.getTracer().withSpan(span);
-    thrown.expect(UnsupportedOperationException.class);
-    thrown.expectMessage("TextFormat.Setter.put");
-    OpenCensusUtils.propagateTracingContext(headers);
-    scope.close();
-    span.end();
+    try {
+      OpenCensusUtils.propagateTracingContext(mockSpan, headers);
+      fail("expected " + UnsupportedOperationException.class);
+    } catch (UnsupportedOperationException e) {
+      assertEquals(e.getMessage(), "TextFormat.Setter.put");
+    }
+  }
+
+  public void testPropagateTracingContextNullSpan() {
+    OpenCensusUtils.setPropagationTextFormat(mockTextFormat);
+    try {
+      OpenCensusUtils.propagateTracingContext(null, headers);
+      fail("expected " + IllegalArgumentException.class);
+    } catch (IllegalArgumentException e) {
+      assertEquals(e.getMessage(), "span should not be null.");
+    }
+  }
+
+  public void testPropagateTracingContextNullHeaders() {
+    OpenCensusUtils.setPropagationTextFormat(mockTextFormat);
+    try {
+      OpenCensusUtils.propagateTracingContext(mockSpan, null);
+      fail("expected " + IllegalArgumentException.class);
+    } catch (IllegalArgumentException e) {
+      assertEquals(e.getMessage(), "headers should not be null.");
+    }
   }
 
   public void testPropagateTracingContextInvalidSpan() {
     OpenCensusUtils.setPropagationTextFormat(mockTextFormat);
     // No injection. No exceptions should be thrown.
-    OpenCensusUtils.propagateTracingContext(headers);
+    OpenCensusUtils.propagateTracingContext(BlankSpan.INSTANCE, headers);
   }
 
   public void testGetEndSpanOptionsNoResponse() {
-    EndSpanOptions expected =
-        EndSpanOptions.builder().setSampleToLocalSpanStore(true).setStatus(Status.UNKNOWN).build();
+    EndSpanOptions expected = EndSpanOptions.builder().setStatus(Status.UNKNOWN).build();
     assertEquals(expected, OpenCensusUtils.getEndSpanOptions(null));
   }
 
   public void testGetEndSpanOptionsSuccess() {
-    EndSpanOptions expected =
-        EndSpanOptions.builder().setSampleToLocalSpanStore(true).setStatus(Status.OK).build();
+    EndSpanOptions expected = EndSpanOptions.builder().setStatus(Status.OK).build();
     assertEquals(expected, OpenCensusUtils.getEndSpanOptions(200));
     assertEquals(expected, OpenCensusUtils.getEndSpanOptions(201));
     assertEquals(expected, OpenCensusUtils.getEndSpanOptions(202));
   }
 
   public void testGetEndSpanOptionsBadRequest() {
-    EndSpanOptions expected = EndSpanOptions
-        .builder()
-        .setSampleToLocalSpanStore(true)
-        .setStatus(Status.INVALID_ARGUMENT)
-        .build();
+    EndSpanOptions expected = EndSpanOptions.builder().setStatus(Status.INVALID_ARGUMENT).build();
     assertEquals(expected, OpenCensusUtils.getEndSpanOptions(400));
   }
 
   public void testGetEndSpanOptionsUnauthorized() {
-    EndSpanOptions expected = EndSpanOptions
-        .builder()
-        .setSampleToLocalSpanStore(true)
-        .setStatus(Status.UNAUTHENTICATED)
-        .build();
+    EndSpanOptions expected = EndSpanOptions.builder().setStatus(Status.UNAUTHENTICATED).build();
     assertEquals(expected, OpenCensusUtils.getEndSpanOptions(401));
   }
 
   public void testGetEndSpanOptionsForbidden() {
-    EndSpanOptions expected = EndSpanOptions
-        .builder()
-        .setSampleToLocalSpanStore(true)
-        .setStatus(Status.PERMISSION_DENIED)
-        .build();
+    EndSpanOptions expected = EndSpanOptions.builder().setStatus(Status.PERMISSION_DENIED).build();
     assertEquals(expected, OpenCensusUtils.getEndSpanOptions(403));
   }
 
   public void testGetEndSpanOptionsNotFound() {
-    EndSpanOptions expected = EndSpanOptions
-        .builder()
-        .setSampleToLocalSpanStore(true)
-        .setStatus(Status.NOT_FOUND)
-        .build();
+    EndSpanOptions expected = EndSpanOptions.builder().setStatus(Status.NOT_FOUND).build();
     assertEquals(expected, OpenCensusUtils.getEndSpanOptions(404));
   }
 
   public void testGetEndSpanOptionsPreconditionFailed() {
-    EndSpanOptions expected = EndSpanOptions
-        .builder()
-        .setSampleToLocalSpanStore(true)
-        .setStatus(Status.FAILED_PRECONDITION)
-        .build();
+    EndSpanOptions expected = EndSpanOptions.builder().setStatus(Status.FAILED_PRECONDITION).build();
     assertEquals(expected, OpenCensusUtils.getEndSpanOptions(412));
   }
 
   public void testGetEndSpanOptionsServerError() {
-    EndSpanOptions expected = EndSpanOptions
-        .builder()
-        .setSampleToLocalSpanStore(true)
-        .setStatus(Status.UNAVAILABLE)
-        .build();
+    EndSpanOptions expected = EndSpanOptions.builder().setStatus(Status.UNAVAILABLE).build();
     assertEquals(expected, OpenCensusUtils.getEndSpanOptions(500));
   }
 
   public void testGetEndSpanOptionsOther() {
-    EndSpanOptions expected = EndSpanOptions.builder()
-        .setSampleToLocalSpanStore(true)
-        .setStatus(Status.UNKNOWN)
-        .build();
+    EndSpanOptions expected = EndSpanOptions.builder().setStatus(Status.UNKNOWN).build();
     // test some random unsupported statuses
     assertEquals(expected, OpenCensusUtils.getEndSpanOptions(301));
     assertEquals(expected, OpenCensusUtils.getEndSpanOptions(402));
     assertEquals(expected, OpenCensusUtils.getEndSpanOptions(501));
+  }
+
+  public void testRecordMessageEventInNullSpan() {
+    try {
+      OpenCensusUtils.recordMessageEvent(null, 0, NetworkEvent.Type.SENT);
+      fail("expected " + IllegalArgumentException.class);
+    } catch (IllegalArgumentException e) {
+      assertEquals(e.getMessage(), "span should not be null.");
+    }
+  }
+
+  public void testRecordMessageEvent() {
+    try {
+      OpenCensusUtils.recordMessageEvent(mockSpan, 0, NetworkEvent.Type.SENT);
+      fail("expected " + UnsupportedOperationException.class);
+    } catch (UnsupportedOperationException e) {
+      assertEquals(e.getMessage(), "Span.addNetworkEvent");
+    }
   }
 }


### PR DESCRIPTION
* Add method and instrumentation to record message events with content-length when sending/receiving
request/response.

* Refine API, add `volatile` modifiers to internal attributes.

* Use `registerSpanNamesForCollection` to replace `setSampleToLocalSpanStore`.

* Add get/set method for recordEvent so users can controll whether to expose collected spans.

* Add more tests and rewrite/fix test cases with JUnit 3 style.

* Fix/refine javadoc and messages.

I have done some basic integration test locally and fix some defects. Codes can be found [here](https://github.com/HailongWen/opencensus-java/blob/google-http-java-client-interop-testing/examples/src/test/java/io/opencensus/examples/trace/GoogleHttpJavaClientInteropTesting.java)

Please @mattwhisenhunt kindly help on merging this PR after @bogdandrutu 's review.
There might be 1 more PR on stats collecting.