### PR TITLE
internal: resolve circular dependency

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/http/HttpRequest.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpRequest.java
@@ -18,7 +18,6 @@ import com.google.api.client.util.Beta;
 import com.google.api.client.util.IOUtils;
 import com.google.api.client.util.LoggingStreamingContent;
 import com.google.api.client.util.ObjectParser;
-import com.google.api.client.util.OpenCensusUtils;
 import com.google.api.client.util.Preconditions;
 import com.google.api.client.util.Sleeper;
 import com.google.api.client.util.StreamingContent;

--- a/google-http-client/src/main/java/com/google/api/client/http/OpenCensusUtils.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/OpenCensusUtils.java
@@ -12,11 +12,9 @@
  * the License.
  */
 
-package com.google.api.client.util;
+package com.google.api.client.http;
 
-import com.google.api.client.http.HttpHeaders;
-import com.google.api.client.http.HttpRequest;
-import com.google.api.client.http.HttpStatusCodes;
+import com.google.api.client.util.Preconditions;
 import com.google.common.annotations.VisibleForTesting;
 
 import io.opencensus.contrib.http.util.HttpPropagationUtil;

--- a/google-http-client/src/test/java/com/google/api/client/http/OpenCensusUtilsTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/OpenCensusUtilsTest.java
@@ -12,7 +12,7 @@
  * the License.
  */
 
-package com.google.api.client.util;
+package com.google.api.client.http;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -21,6 +21,7 @@ import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.verify;
 
 import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.OpenCensusUtils;
 import io.opencensus.trace.EndSpanOptions;
 import io.opencensus.trace.NetworkEvent;
 import io.opencensus.trace.Span;


### PR DESCRIPTION
Resolves a circular dependency:

`utils.OpenCensusUtils` depends on `http.HttpHeaders`, `http.HttpHeaders` depends on `utils.*`.

The change is to move `utils.OpenCensusUtils` to `http.OpenCensusUtils`, which is not the greatest solution but should work.

Maven doesn't care but google's internal build tooling does care.