### PR TITLE
supress MustBeClosed

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/http/HttpRequest.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpRequest.java
@@ -1003,6 +1003,7 @@ public final class HttpRequest {
       // execute
       lowLevelHttpRequest.setTimeout(connectTimeout, readTimeout);
       // switch tracing scope to current span
+      @SuppressWarnings("MustBeClosedChecker")
       Scope ws = tracer.withSpan(span);
       OpenCensusUtils.recordSentMessageEvent(
           span, sentIdGenerator++, lowLevelHttpRequest.getContentLength());


### PR DESCRIPTION
This code does not compile internally.

Internal error: 

```
error: [MustBeClosedChecker] The result of this method must be closed.
      Scope ws = tracer.withSpan(span);
```