### PR TITLE
base64: strip carriage returns and newlines

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/util/Base64.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/Base64.java
@@ -105,6 +105,9 @@ public class Base64 {
       return null;
     }
 
+    base64String = base64String.replace("\r", "");
+    base64String = base64String.replace("\n", "");
+
     try {
       return BaseEncoding.base64().decode(base64String);
     } catch (IllegalArgumentException e) {

--- a/google-http-client/src/test/java/com/google/api/client/util/Base64Test.java
+++ b/google-http-client/src/test/java/com/google/api/client/util/Base64Test.java
@@ -13,6 +13,7 @@
  */
 package com.google.api.client.util;
 
+import java.util.Arrays;
 import junit.framework.TestCase;
 
 /**
@@ -53,5 +54,11 @@ public class Base64Test extends TestCase {
   public void testDecode() {
     String value = new String(Base64.decodeBase64(Base64.encodeBase64("foobar".getBytes())));
     assertEquals("foobar", value);
+  }
+
+  public void testDecodeStripsCarriageReturnsAndNewlines() {
+    byte[] actual = Base64.decodeBase64("aGVsbG8gd29ybGQ=\r\n");
+    byte[] expected = "hello world".getBytes();
+    assertTrue(Arrays.equals(actual, expected));
   }
 }


### PR DESCRIPTION
The guava [1] doc mentions that carriage returns and newlines are not
permitted, and recommend using .withSeparator. We do not know whether
the input string will contain a carriage return, or a newline, or both,
so instead we'll just strip them each individually.

This fixes an internal google bug that was introduced in as part of
the move from Apache Commons Codec to Guava in
ef9f9142be5dacdd19a3a16f37000eca478d2d51.

1: https://google.github.io/guava/releases/19.0/api/docs/com/google/common/io/BaseEncoding.html#withSeparator(java.lang.String,%20int)