### PR TITLE
Fixed calls to toLowerCase() to be toLowerCase(Locale.US) instead.

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/http/GenericUrl.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/GenericUrl.java
@@ -30,6 +30,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -155,7 +156,7 @@ public class GenericUrl extends GenericData {
       String fragment,
       String query,
       String userInfo) {
-    this.scheme = scheme.toLowerCase();
+    this.scheme = scheme.toLowerCase(Locale.US);
     this.host = host;
     this.port = port;
     this.pathParts = toPathParts(path);

--- a/google-http-client/src/main/java/com/google/api/client/http/HttpHeaders.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpHeaders.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -1035,7 +1036,7 @@ public class HttpHeaders extends GenericData {
    * @since 1.13
    */
   public String getFirstHeaderStringValue(String name) {
-    Object value = get(name.toLowerCase());
+    Object value = get(name.toLowerCase(Locale.US));
     if (value == null) {
       return null;
     }
@@ -1056,7 +1057,7 @@ public class HttpHeaders extends GenericData {
    * @since 1.13
    */
   public List<String> getHeaderStringValues(String name) {
-    Object value = get(name.toLowerCase());
+    Object value = get(name.toLowerCase(Locale.US));
     if (value == null) {
       return Collections.emptyList();
     }

--- a/google-http-client/src/main/java/com/google/api/client/http/HttpMediaType.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/HttpMediaType.java
@@ -18,6 +18,7 @@ import com.google.api.client.util.Preconditions;
 
 import java.nio.charset.Charset;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.SortedMap;
@@ -200,7 +201,7 @@ public final class HttpMediaType {
     Preconditions.checkArgument(
         TOKEN_REGEX.matcher(name).matches(), "Name contains reserved characters");
     cachedBuildResult = null;
-    parameters.put(name.toLowerCase(), value);
+    parameters.put(name.toLowerCase(Locale.US), value);
     return this;
   }
 
@@ -210,7 +211,7 @@ public final class HttpMediaType {
    * @param name name of the parameter
    */
   public String getParameter(String name) {
-    return parameters.get(name.toLowerCase());
+    return parameters.get(name.toLowerCase(Locale.US));
   }
 
   /**
@@ -220,7 +221,7 @@ public final class HttpMediaType {
    */
   public HttpMediaType removeParameter(String name) {
     cachedBuildResult = null;
-    parameters.remove(name.toLowerCase());
+    parameters.remove(name.toLowerCase(Locale.US));
     return this;
   }
 

--- a/google-http-client/src/main/java/com/google/api/client/testing/http/MockLowLevelHttpRequest.java
+++ b/google-http-client/src/main/java/com/google/api/client/testing/http/MockLowLevelHttpRequest.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
 
@@ -75,7 +76,7 @@ public class MockLowLevelHttpRequest extends LowLevelHttpRequest {
 
   @Override
   public void addHeader(String name, String value) throws IOException {
-    name = name.toLowerCase();
+    name = name.toLowerCase(Locale.US);
     List<String> values = headersMap.get(name);
     if (values == null) {
       values = new ArrayList<String>();
@@ -119,7 +120,7 @@ public class MockLowLevelHttpRequest extends LowLevelHttpRequest {
    * @since 1.13
    */
   public String getFirstHeaderValue(String name) {
-    List<String> values = headersMap.get(name.toLowerCase());
+    List<String> values = headersMap.get(name.toLowerCase(Locale.US));
     return values == null ? null : values.get(0);
   }
 
@@ -130,7 +131,7 @@ public class MockLowLevelHttpRequest extends LowLevelHttpRequest {
    * @since 1.13
    */
   public List<String> getHeaderValues(String name) {
-    List<String> values = headersMap.get(name.toLowerCase());
+    List<String> values = headersMap.get(name.toLowerCase(Locale.US));
     return values == null ? Collections.<String>emptyList() : Collections.unmodifiableList(values);
   }
 

--- a/google-http-client/src/main/java/com/google/api/client/util/ClassInfo.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/ClassInfo.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.IdentityHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.TreeSet;
 import java.util.WeakHashMap;
@@ -121,7 +122,7 @@ public final class ClassInfo {
   public FieldInfo getFieldInfo(String name) {
     if (name != null) {
       if (ignoreCase) {
-        name = name.toLowerCase();
+        name = name.toLowerCase(Locale.US);
       }
       name = name.intern();
     }
@@ -175,7 +176,7 @@ public final class ClassInfo {
       }
       String fieldName = fieldInfo.getName();
       if (ignoreCase) {
-        fieldName = fieldName.toLowerCase().intern();
+        fieldName = fieldName.toLowerCase(Locale.US).intern();
       }
       FieldInfo conflictingFieldInfo = nameToFieldInfoMap.get(fieldName);
       Preconditions.checkArgument(conflictingFieldInfo == null,

--- a/google-http-client/src/main/java/com/google/api/client/util/DataMap.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/DataMap.java
@@ -17,6 +17,7 @@ package com.google.api.client.util;
 import java.util.AbstractMap;
 import java.util.AbstractSet;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.Map;
 import java.util.NoSuchElementException;
 
@@ -204,7 +205,7 @@ final class DataMap extends AbstractMap<String, Object> {
     public String getKey() {
       String result = fieldInfo.getName();
       if (classInfo.getIgnoreCase()) {
-        result = result.toLowerCase();
+        result = result.toLowerCase(Locale.US);
       }
       return result;
     }

--- a/google-http-client/src/main/java/com/google/api/client/util/GenericData.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/GenericData.java
@@ -18,6 +18,7 @@ import java.util.AbstractMap;
 import java.util.AbstractSet;
 import java.util.EnumSet;
 import java.util.Iterator;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
@@ -90,7 +91,7 @@ public class GenericData extends AbstractMap<String, Object> implements Cloneabl
       return fieldInfo.getValue(this);
     }
     if (classInfo.getIgnoreCase()) {
-      fieldName = fieldName.toLowerCase();
+      fieldName = fieldName.toLowerCase(Locale.US);
     }
     return unknownFields.get(fieldName);
   }
@@ -104,7 +105,7 @@ public class GenericData extends AbstractMap<String, Object> implements Cloneabl
       return oldValue;
     }
     if (classInfo.getIgnoreCase()) {
-      fieldName = fieldName.toLowerCase();
+      fieldName = fieldName.toLowerCase(Locale.US);
     }
     return unknownFields.put(fieldName, value);
   }
@@ -125,7 +126,7 @@ public class GenericData extends AbstractMap<String, Object> implements Cloneabl
       fieldInfo.setValue(this, value);
     } else {
       if (classInfo.getIgnoreCase()) {
-        fieldName = fieldName.toLowerCase();
+        fieldName = fieldName.toLowerCase(Locale.US);
       }
       unknownFields.put(fieldName, value);
     }
@@ -150,7 +151,7 @@ public class GenericData extends AbstractMap<String, Object> implements Cloneabl
       throw new UnsupportedOperationException();
     }
     if (classInfo.getIgnoreCase()) {
-      fieldName = fieldName.toLowerCase();
+      fieldName = fieldName.toLowerCase(Locale.US);
     }
     return unknownFields.remove(fieldName);
   }


### PR DESCRIPTION
The no-arg method uses Locale.getDefault() internally. On an Android device, this uses the currently active Locale. If the currently active locale happens to be Turkish, then uppercase "I" becomes a non-ASCII unicode character 'LATIN SMALL LETTER DOTLESS I'.

This specifically manifested as the header X-Goog-Encode-Response-If-Executable being rejected by the okhttp library because it contained the non-ASCII character.

NOTE: this commit was originally written by @stuartfehr