### PR TITLE
fix pom to include correct guava version

### DIFF
--- a/google-http-client/pom.xml
+++ b/google-http-client/pom.xml
@@ -55,7 +55,7 @@
             <configuration>
               <includes>
                 <include>commons-codec:commons-codec</include>
-                <include>com.google.guava:guava-jdk5</include>
+                <include>com.google.guava:guava</include>
               </includes>
               <rules>
                 <rule>


### PR DESCRIPTION
This fixes a bug wherein the jarjar repackaging rules would incorrectly repackage the jar such that the packaged result is unusable, despite the non-packaged code and tests running fine.