### PR TITLE
remove <keep>com.google.api.client.**, fixing packaging

### DIFF
--- a/google-http-client/pom.xml
+++ b/google-http-client/pom.xml
@@ -66,9 +66,6 @@
                   <pattern>com.google.common.**</pattern>
                   <result>com.google.api.client.repackaged.com.google.common.@1</result>
                 </rule>
-                <keep>
-                  <pattern>com.google.api.client.**</pattern>
-                </keep>
               </rules>
             </configuration>
           </execution>


### PR DESCRIPTION
Before this commit, packaging is broken: the google oauth and api libraries depend on this library repackaging guava in a specific way. Parts of the jarjar configuration (above the keep declaration) do just that. However, for some reason, not all of the guava classes seem to be included: for instance, oauth will complain that the following class is missing: com/google/api/client/repackaged/com/google/common/base/Platform.

What gives? guava-20 certainly contains that class. Even more strange, there _are_ things in that directory, just not _all_ of the classes expected. So, _some_ guava things are obviously being repackaged.

Well, the inclusion of the keep rule removed in this commit somehow seems to either:
- Repackage a very old version of guava that does not have all the classes that newer code expects
- Remove some classes

I suspect the former. Either way, this change makes all three libraries `mvn clean install` without a problem, and does not seem to have a negative impact (e.g., the existence of com.google.api.client classes in the jar does not seem predicated on this keep being present - confirmed with "jar tf targets/etc/etc").