### PR TITLE
Make GenericUrl's #equals pass static analysis

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/http/GenericUrl.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/GenericUrl.java
@@ -182,7 +182,7 @@ public class GenericUrl extends GenericData {
     }
     GenericUrl other = (GenericUrl) obj;
     // TODO(yanivi): optimize?
-    return build().equals(other.toString());
+    return build().equals(other.build());
   }
 
   @Override


### PR DESCRIPTION
We'll start matching this with a new error-prone (https://github.com/google/error-prone) check soon otherwise: it looks like this is comparing two different getters.