### PR TITLE
Fix throwIfFalseEOF if skip method was called before read

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/http/javanet/NetHttpResponse.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/javanet/NetHttpResponse.java
@@ -186,6 +186,17 @@ final class NetHttpResponse extends LowLevelHttpResponse {
       return n;
     }
 
+    @Override
+    public long skip(long n) throws IOException {
+      int n = in.skip(n);
+      if (n == -1) {
+        throwIfFalseEOF();
+      } else {
+        bytesRead += n;
+      }
+      return n;
+    }
+
     // Throws an IOException if gets an EOF in the middle of a response.
     private void throwIfFalseEOF() throws IOException {
       long contentLength = getContentLength();

--- a/google-http-client/src/main/java/com/google/api/client/http/javanet/NetHttpResponse.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/javanet/NetHttpResponse.java
@@ -187,8 +187,8 @@ final class NetHttpResponse extends LowLevelHttpResponse {
     }
 
     @Override
-    public long skip(long n) throws IOException {
-      int n = in.skip(n);
+    public long skip(long len) throws IOException {
+      int n = in.skip(len);
       if (n == -1) {
         throwIfFalseEOF();
       } else {

--- a/google-http-client/src/main/java/com/google/api/client/http/javanet/NetHttpResponse.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/javanet/NetHttpResponse.java
@@ -188,7 +188,7 @@ final class NetHttpResponse extends LowLevelHttpResponse {
 
     @Override
     public long skip(long len) throws IOException {
-      int n = in.skip(len);
+      long n = in.skip(len);
       if (n == -1) {
         throwIfFalseEOF();
       } else {

--- a/google-http-client/src/main/java/com/google/api/client/http/javanet/NetHttpResponse.java
+++ b/google-http-client/src/main/java/com/google/api/client/http/javanet/NetHttpResponse.java
@@ -189,11 +189,7 @@ final class NetHttpResponse extends LowLevelHttpResponse {
     @Override
     public long skip(long len) throws IOException {
       long n = in.skip(len);
-      if (n == -1) {
-        throwIfFalseEOF();
-      } else {
-        bytesRead += n;
-      }
+      bytesRead += n;
       return n;
     }
 

--- a/google-http-client/src/test/java/com/google/api/client/http/javanet/NetHttpResponseTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/javanet/NetHttpResponseTest.java
@@ -94,4 +94,18 @@ public class NetHttpResponseTest extends TestCase {
       assertEquals(ERROR_RESPONSE, new String(buf, 0, bytes, Charset.forName("UTF-8")));
     }
   }
+
+  public void testSkippingBytes() throws IOException {
+    MockHttpURLConnection connection = new MockHttpURLConnection(null)
+        .setResponseCode(200)
+        .setInputStream(new ByteArrayInputStream(StringUtils.getBytesUtf8("0123456789")))
+        .addHeader("Content-Length", "10");
+    NetHttpResponse response = new NetHttpResponse(connection);
+    InputStream is = response.getContent();
+    // read 1 byte, then skip 9 (to EOF)
+    assertEquals('0', is.read());
+    assertEquals(9, is.skip(9));
+    // expect EOF, not an exception
+    assertEquals(-1, is.read());
+  }
 }


### PR DESCRIPTION
throwIfFalseEOF method don't take into account bytes read/skipped in skip method and throws IOException when legit EOF was reached.