### PR TITLE
Fix compilation for Java 10

### DIFF
--- a/.kokoro/presubmit/java9.cfg
+++ b/.kokoro/presubmit/java9.cfg
@@ -1,7 +1,0 @@
-# Format: //devtools/kokoro/config/proto/build.proto
-
-# Configure the docker image for kokoro-trampoline.
-env_vars: {
-    key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/java9"
-}

--- a/google-http-client-jdo/pom.xml
+++ b/google-http-client-jdo/pom.xml
@@ -54,10 +54,32 @@
       </plugin>
       <plugin>
         <groupId>org.datanucleus</groupId>
-        <artifactId>maven-datanucleus-plugin</artifactId>
+        <artifactId>datanucleus-maven-plugin</artifactId>
+        <version>${project.datanucleus-maven-plugin.version}</version>
         <configuration>
+          <api>JDO</api>
           <verbose>true</verbose>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.datanucleus</groupId>
+            <artifactId>datanucleus-core</artifactId>
+            <version>${project.datanucleus-core.version}</version>
+            <scope>runtime</scope>
+          </dependency>
+          <dependency>
+            <groupId>org.datanucleus</groupId>
+            <artifactId>datanucleus-api-jdo</artifactId>
+            <version>${project.datanucleus-api-jdo.version}</version>
+            <scope>runtime</scope>
+          </dependency>
+          <dependency>
+            <groupId>javax.jdo</groupId>
+            <artifactId>jdo2-api</artifactId>
+            <version>${project.jdo2-api.version}</version>
+            <scope>runtime</scope>
+          </dependency>
+        </dependencies>
         <executions>
           <execution>
             <phase>process-classes</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -242,17 +242,17 @@
       <dependency>
         <groupId>org.datanucleus</groupId>
         <artifactId>datanucleus-core</artifactId>
-        <version>3.2.2</version>
+        <version>${project.datanucleus-core.version}</version>
       </dependency>
       <dependency>
         <groupId>org.datanucleus</groupId>
         <artifactId>datanucleus-api-jdo</artifactId>
-        <version>3.2.1</version>
+        <version>${project.datanucleus-api-jdo.version}</version>
       </dependency>
       <dependency>
         <groupId>org.datanucleus</groupId>
         <artifactId>datanucleus-rdbms</artifactId>
-        <version>3.2.1</version>
+        <version>${project.datanucleus-rdbms.version}</version>
       </dependency>
       <dependency>
         <groupId>mysql</groupId>
@@ -382,7 +382,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>clirr-maven-plugin</artifactId>
-          <version>2.6</version>
+          <version>2.8</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -402,7 +402,7 @@
         <plugin>
           <groupId>org.datanucleus</groupId>
           <artifactId>maven-datanucleus-plugin</artifactId>
-          <version>2.2.1</version>
+          <version>${project.datanucleus-maven-plugin.version}</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -562,5 +562,9 @@
     <project.commons-logging.version>1.1.1</project.commons-logging.version>
     <project.httpclient.version>4.5.5</project.httpclient.version>
     <project.jdo2-api.version>2.3-eb</project.jdo2-api.version>
+    <project.datanucleus-core.version>3.2.2</project.datanucleus-core.version>
+    <project.datanucleus-api-jdo.version>3.2.1</project.datanucleus-api-jdo.version>
+    <project.datanucleus-rdbms.version>3.2.1</project.datanucleus-rdbms.version>
+    <project.datanucleus-maven-plugin.version>4.0.3</project.datanucleus-maven-plugin.version>
   </properties>
 </project>


### PR DESCRIPTION
* Update datanucleus plugin versions to build on Java 9/10.
* Update clirr-maven-plugin to 2.8 to work on Java 10.
* Removing Java 9 from the test matrix as we cannot resolve the issue and guava does not seem to work on Java 9 anyways.