### PR TITLE
Fix plus signs in URL paths.

### DIFF
--- a/google-http-client/src/main/java/com/google/api/client/util/escape/CharEscapers.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/escape/CharEscapers.java
@@ -97,6 +97,20 @@ public final class CharEscapers {
   }
 
   /**
+   * Percent-decodes a URI path string into a Unicode string. UTF-8 encoding is used to determine
+   * what characters are represented by any consecutive sequences of the form "%<i>XX</i>".
+   *
+   * @param path a percent-encoded US-ASCII string
+   * @return a Unicode string
+   */
+  public static String decodeUriPath(String path) {
+    // Encode plus signs in this path component so that it can be handled by URLDecoder.decode
+    // and we don't have to reimplement the entire decode method to handle +'s in paths.
+    return decodeUri(path.replace("+", "%2B"));
+
+  }
+
+  /**
    * Escapes the string value so it can be safely included in URI path segments. For details on
    * escaping URIs, see <a href="http://tools.ietf.org/html/rfc3986#section-2.4">RFC 3986 - section
    * 2.4</a>.

--- a/google-http-client/src/main/java/com/google/api/client/util/escape/PercentEscaper.java
+++ b/google-http-client/src/main/java/com/google/api/client/util/escape/PercentEscaper.java
@@ -68,7 +68,7 @@ public class PercentEscaper extends UnicodeEscaper {
    * specified in RFC 3986. Note that some of these characters do need to be escaped when used in
    * other parts of the URI.
    */
-  public static final String SAFEPATHCHARS_URLENCODER = "-_.!~*'()@:$&,;=";
+  public static final String SAFEPATHCHARS_URLENCODER = "-_.!~*'()@:$&,;=+";
 
   /**
    * Contains the save characters plus all reserved characters. This happens to be the safe path

--- a/google-http-client/src/test/java/com/google/api/client/http/GenericUrlTest.java
+++ b/google-http-client/src/test/java/com/google/api/client/http/GenericUrlTest.java
@@ -15,6 +15,7 @@
 package com.google.api.client.http;
 
 import com.google.api.client.util.Key;
+import com.google.common.collect.ImmutableList;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -588,5 +589,24 @@ public class GenericUrlTest extends TestCase {
     GenericUrl gu = new GenericUrl(url);
     GenericUrl redirectedUrl = new GenericUrl(gu.toURL(relative));
     assertEquals(expectedResult, redirectedUrl.toString());
+  }
+
+  public void testPlusPaths_notEscaped() {
+    String input = "https://plus.google.com/+username/posts/postid";
+    GenericUrl url = new GenericUrl(input);
+    assertEquals(input, url.toString());
+  }
+
+  public void testEscapedPlusPaths_notEscaped() {
+    String input = "https://plus.google.com/%2Busername/posts/postid";
+    GenericUrl url = new GenericUrl(input);
+    assertEquals(input, url.toString());
+  }
+
+  public void testPathParts() {
+    final GenericUrl genericUrl = new GenericUrl("http://foo.bar/path+with+plus");
+
+    assertEquals("/path+with+plus", genericUrl.getRawPath());
+    assertEquals(ImmutableList.of("", "path+with+plus"), genericUrl.getPathParts());
   }
 }


### PR DESCRIPTION
When building a URL, store the rawPath. When dealing with pathParts, you
will deal with decoded values, but toString() and getRawPath() deal with
encoded strings.